### PR TITLE
add presets scaffold; enhance lucky word functions in welcome panel; prepare for custom shells functions

### DIFF
--- a/biscuit/core/components/editors/misc/welcome.py
+++ b/biscuit/core/components/editors/misc/welcome.py
@@ -26,6 +26,13 @@ class Welcome(BaseEditor):
         self.description = Label(self.left, text="Made with ❤", font=("Segoe UI", 20), fg=self.base.theme.biscuit_dark, **self.base.theme.editors.biscuit_labels)
         self.description.grid(row=1, column=0, sticky=tk.W, pady=5)
 
+        if self.base.get_user_preset("editing.misc.welcome.lucky"):
+            lucky_word = self.base.get_user_preset("editing.misc.welcome.lucky")
+            self.lucky = Label(self.left, text=lucky_word, font=("Segoe UI", 14), fg=self.base.theme.biscuit_dark, **self.base.theme.editors.biscuit_labels)
+            self.lucky.grid(row=2, column=0, sticky=tk.W, pady=1)
+        else:
+            self.lucky = None
+
         self.create_start_group()
         self.create_recent_group()
 

--- a/presets/README.md
+++ b/presets/README.md
@@ -1,0 +1,12 @@
+Here is a directory that holds and shows preset. Write a preset for yourself as you need.
+
+Look for the `empty.py` that shows a preset empty.
+
+Look for the `example.lucky.py` that shows how to setup a lucky word in the welcome panel; a panel that will start at first.
+
+Look for the `example.shells.py` that shows how to setup multiple shells.
+
+Feel free to merge them. After editing, move the preset as `~/.biscuit/preset.entry.py`.
+
+That's all!
+

--- a/presets/example.lucky.py
+++ b/presets/example.lucky.py
@@ -1,0 +1,14 @@
+
+# Preset for Editing-wide
+class editing:
+    class misc:
+        class welcome:
+            lucky = "Don't you want me, On!"
+
+# Preset for Feature-wide
+class features:
+    pass
+
+# Preset for Extendsions
+class extensions:
+    pass

--- a/presets/example.shells.py
+++ b/presets/example.shells.py
@@ -1,0 +1,14 @@
+
+# Preset for Editing-wide
+class editing:
+    class shells:
+        _1 = {}
+        _2 = {}
+
+# Preset for Feature-wide
+class features:
+    pass
+
+# Preset for Extendsions
+class extensions:
+    pass


### PR DESCRIPTION
Add a scaffold for read and use users custom presets. 

For the welcome panel, I have test the lucky word would work; however it may not a good typograph, so it may need a further consider or design.

I don't yet have a clear idea how should multiple shells customized. I thinks users can write some indexed preset in the preset file, and pass some name in editing, for guiding how to run multiple shells.

Maybe it will good for a discussion a more manner way to setup presets; for example, a helping window that gen presets file and recover.