### PR TITLE
fix: Window now closes when 'x' is clicked

### DIFF
--- a/biscuit/core/commands.py
+++ b/biscuit/core/commands.py
@@ -91,7 +91,7 @@ class Commands:
 
     def quit(self, *_) -> None:
         self.base.on_close_app()
-        self.base.destroy()
+        # self.base.destroy()
 
     def toggle_maximize(self, *_) -> None:
         match platform.system():

--- a/biscuit/core/gui.py
+++ b/biscuit/core/gui.py
@@ -143,6 +143,7 @@ class GUIManager(Tk, ConfigManager):
     
     def on_close_app(self) -> None:
         self.editorsmanager.delete_all_editors()
+        self.destroy()
 
     def on_focus(self, *_) -> None:
         for fn in self.onfocus_callbacks:


### PR DESCRIPTION
The commit 30a251c has made the biscuit window to not close when 'x' is clicked. This is probably due to the "WM_DELETE_WINDOW" protocol only calling the [on_close_app](https://github.com/tomlin7/biscuit/blob/83437bd90fc4003d4a09ba47cb9445fe34f7f9c7/biscuit/core/gui.py#L64) function, which does not `destroy()` the tkinter window.

I checked the previous commit c9dd044 and this does close the window, so i guess the addition of the "WM_DELETE_WINDOW" protocol might have introduced the bug