### PR TITLE
fix: Fix PRs being displayed with issues

### DIFF
--- a/biscuit/core/components/views/sidebar/github/issues.py
+++ b/biscuit/core/components/views/sidebar/github/issues.py
@@ -48,7 +48,7 @@ class Issues(SidebarViewItem):
         try:
             item = self.tree.selection()[0]
             link = self.tree.item(item, "values")[0]
-            webbrowser.open(link)
+            webbrowser.open(link)d
         except Exception as e:
             pass
     
@@ -65,16 +65,8 @@ class Issues(SidebarViewItem):
             self.tree.insert('', tk.END, text="No open issues")
             return
         
-        for index, issue in enumerate(issues):
-            # Remove the pull requests from issues
-            try:
-                issue["pull_request"]
-                del issues[index]
-            except KeyError:
-                pass
-
-        self.issues_actionset.update([(f"{issue['title']} #{issue['number']}", lambda *_, link=issue['html_url']: webbrowser.open(link)) for issue in issues])
-        issues = ((f"{issue['title']} #{issue['number']}", issue['html_url']) for issue in issues)
+        self.issues_actionset.update([(f"{issue['title']} #{issue['number']}", lambda *_, link=issue['html_url']: webbrowser.open(link)) for issue in issues if 'pull_request' not in issue])
+        issues = ((f"{issue['title']} #{issue['number']}", issue['html_url']) for issue in issues if 'pull_request' not in issue)
 
         self.tree.delete(*self.tree.get_children())
         for issue in issues:

--- a/biscuit/core/components/views/sidebar/github/issues.py
+++ b/biscuit/core/components/views/sidebar/github/issues.py
@@ -65,6 +65,14 @@ class Issues(SidebarViewItem):
             self.tree.insert('', tk.END, text="No open issues")
             return
         
+        for index, issue in enumerate(issues):
+            # Remove the pull requests from issues
+            try:
+                issue["pull_request"]
+                del issues[index]
+            except KeyError:
+                pass
+
         self.issues_actionset.update([(f"{issue['title']} #{issue['number']}", lambda *_, link=issue['html_url']: webbrowser.open(link)) for issue in issues])
         issues = ((f"{issue['title']} #{issue['number']}", issue['html_url']) for issue in issues)
 

--- a/biscuit/core/components/views/sidebar/github/issues.py
+++ b/biscuit/core/components/views/sidebar/github/issues.py
@@ -48,7 +48,7 @@ class Issues(SidebarViewItem):
         try:
             item = self.tree.selection()[0]
             link = self.tree.item(item, "values")[0]
-            webbrowser.open(link)d
+            webbrowser.open(link)
         except Exception as e:
             pass
     


### PR DESCRIPTION
> Note: GitHub's REST API considers every pull request an issue, but not every issue is a pull request. For this reason, "Issues" endpoints may return both issues and pull requests in the response.

In the API [docs](https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#list-repository-issues), it shows that the PRs also get included in the issues. So biscuit was also showing PRs with the issues. This PR should fix that.