### PR TITLE
fix: Fixed issues with basedpyright-langserver, Send empty configurations after server initialization

### DIFF
--- a/src/biscuit/common/io.py
+++ b/src/biscuit/common/io.py
@@ -67,6 +67,10 @@ class IO:
         self.t_out = Thread(target=self._process_out, daemon=True)
         self.t_out.start()
 
+        # Debugging purposes
+        # self.t_err = Thread(target=self._process_err, daemon=True)
+        # self.t_err.start()
+
     def stop(self, *_) -> None:
         """Stop the process"""
 
@@ -93,3 +97,10 @@ class IO:
             if not data:
                 break
             self.out_queue.put(data)
+
+    def _process_err(self) -> None:
+        while self.alive:
+            data = self.p.stderr.read(1)
+            if not data:
+                break
+            print(data.decode(), end="", flush=True)  # Print to the console

--- a/src/biscuit/common/notifications/manager.py
+++ b/src/biscuit/common/notifications/manager.py
@@ -82,6 +82,8 @@ class Notifications(Toplevel):
         instance.pack(side=tk.TOP, fill=tk.BOTH, expand=1, pady=(0, 1))
         self.count += 1
         self.show()
+        self.update_idletasks()
+        self._follow_root()
 
         self.notifications.append(instance)
         self.latest = instance
@@ -101,6 +103,8 @@ class Notifications(Toplevel):
         instance.pack(side=tk.TOP, fill=tk.BOTH, expand=1, pady=(0, 1))
         self.count += 1
         self.show()
+        self.update_idletasks()
+        self._follow_root()
 
         self.notifications.append(instance)
         self.latest = instance
@@ -118,6 +122,8 @@ class Notifications(Toplevel):
         instance.pack(side=tk.TOP, fill=tk.BOTH, expand=1, pady=(0, 1))
         self.count += 1
         self.show()
+        self.update_idletasks()
+        self._follow_root()
 
         self.notifications.append(instance)
         self.latest = instance

--- a/src/biscuit/language/handler.py
+++ b/src/biscuit/language/handler.py
@@ -28,9 +28,20 @@ class EventHandler:
     def process(self, e: lsp.Event) -> None:
         """Process the event"""
 
+        # print(e.__class__.__name__.upper(), e, end="\n\n")
+
         if isinstance(e, lsp.Shutdown):
             self.client.exit()
             return
+
+        if isinstance(e, lsp.ConfigurationRequest):
+            self.base.logger.warning("Config asked for: ", e.items)
+            e.reply([])
+            return
+
+        # if isinstance(e, lsp.WorkspaceFolders):
+        #     e.reply([lsp.WorkspaceFolder(uri=self.root_uri, name="Root")])
+        #     return
 
         if isinstance(e, lsp.LogMessage):
             self.base.logger.rawlog(e.message, e.type)
@@ -44,7 +55,14 @@ class EventHandler:
             self.base.logger.info("Capabilities " + pprint.pformat(e.capabilities))
             for tab in self.master.tabs_opened:
                 self.master.open_tab(tab)
-                self.master.request_outline(tab)
+                # self.master.request_outline(tab)
+
+            self.client._send_notification(
+                method="workspace/didChangeConfiguration",
+                params={
+                    "settings": [],
+                },
+            )
 
             self.base.statusbar.process_indicator.hide()
             return


### PR DESCRIPTION
fix #364 

- send an empty configuration after initialization with `workspace/didChangeConfiguration`