### PR TITLE
Submenus support for biscuit menus

### DIFF
--- a/src/biscuit/common/menu/menu.py
+++ b/src/biscuit/common/menu/menu.py
@@ -1,16 +1,20 @@
-# TODO Menus
-# - Have various types of menus
-# - Context menus for various buttons across the editor
-# - Make the api more clean and easy to use like palette
-#   - isolate tkinter_menus library
+from __future__ import annotations
 
 import tkinter as tk
 from typing import Callable, Union
+
+from biscuit.common.menu.submenu import SubMenu
 
 from ..ui import Frame, Toplevel
 from .checkable import Checkable
 from .command import Command
 from .separator import Separator
+
+# TODO Menus
+# - Have various types of menus
+# - Context menus for various buttons across the editor
+# - Make the api more clean and easy to use like palette
+#   - isolate tkinter_menus library
 
 
 class Menu(Toplevel):
@@ -45,10 +49,12 @@ class Menu(Toplevel):
         self.menu_items = []
         self.row = 0
 
+        self.hold_focus = False
+
         self.config_bindings()
 
     def config_bindings(self) -> None:
-        self.bind("<FocusOut>", self.hide)
+        self.bind("<FocusOut>", self.hide_check)
         self.bind("<Escape>", self.hide)
 
     def get_coords(self, *e) -> tuple:
@@ -92,6 +98,14 @@ class Menu(Toplevel):
         self.active = False
         self.withdraw()
         self.master.event_generate("<<Hide>>")
+
+    def hide_check(self, e) -> None:
+        """If submenus are active, dont hide the menu"""
+
+        if self.hold_focus:
+            return
+
+        self.hide()
 
     def add_item(self, item: Union[Command, Checkable]) -> Command:
         """Add a menu item to the menu
@@ -152,6 +166,18 @@ class Menu(Toplevel):
 
         self.row += 1
         return new_sep
+
+    def add_menu(self, text: str) -> SubMenu:
+        """Add a new menu to the menu
+
+        Args:
+            text (str): The text of the menu
+
+        Returns:
+            Menu: The created menu"""
+
+        new_item = SubMenu(self, self.container, text)
+        return self.add_item(new_item)
 
     def clear(self) -> None:
         """Clear all menu items from the menu"""

--- a/src/biscuit/common/menu/submenu.py
+++ b/src/biscuit/common/menu/submenu.py
@@ -1,0 +1,55 @@
+import tkinter as tk
+
+from biscuit.common.icons import Icons
+from biscuit.common.ui import IconLabelButton
+
+
+class SubMenu(IconLabelButton):
+    """SubMenu"""
+
+    def __init__(self, main, master, text, *args, **kwargs) -> None:
+        """Create a submenu item
+
+        Args:
+            master: The parent widget
+            text: The text to display on the menu item
+        """
+
+        super().__init__(
+            master,
+            text,
+            Icons.CHEVRON_RIGHT,
+            expandicon=False,
+            iconsize=10,
+            iconside=tk.RIGHT,
+            *args,
+            **kwargs
+        )
+        self.main = main
+
+        from .menu import Menu
+
+        class SubMenu(Menu):
+            def __init__(self, master, text, *args, **kwargs) -> None:
+                super().__init__(master, *args, **kwargs)
+
+            def get_coords(self) -> None:
+                return (
+                    self.master.winfo_rootx() + self.master.winfo_width(),
+                    self.master.winfo_rooty(),
+                )
+
+        self.menu = SubMenu(self, text)
+
+        self.bind("<Enter>", self.on_enter)
+        self.bind("<Leave>", self.on_leave)
+
+    def on_enter(self, e) -> None:
+        self.main.hold_focus = True
+        self.menu.show()
+
+    def on_leave(self, e=None) -> None:
+        self.main.hold_focus = False
+        # self.menu.hide()
+
+    def on_click(self, *_) -> None: ...


### PR DESCRIPTION
fix #252 

Added support for submenus. 

- [x] Shown on hovering the menu item submenus are attached to. 
- [x] Submenus are hidden only when the main menu loses focus.
- [x] If another submenu of same parent is shown, current one shall hide

![image](https://github.com/user-attachments/assets/ae001f75-fb06-4b70-8c28-b58864cc8c2e)
