### PR TITLE
Extensions userlevel

### DIFF
--- a/src/biscuit/config.py
+++ b/src/biscuit/config.py
@@ -37,7 +37,7 @@ class ConfigManager:
     # constants
     resdir: str
     appdir: str
-    extensionsdir: str
+    extensiondir: str
     git_found = False
     wrap_words = False
     tab_spaces = 4
@@ -90,7 +90,12 @@ class ConfigManager:
             self.parentdir = Path(self.appdir).parent.parent.absolute()
 
         self.configdir = os.path.join(self.parentdir, "config")
-        self.extensionsdir = os.path.join(self.parentdir, "extensions")
+
+        self.extensiondir = Path.home() / ".biscuit" / "extensions"
+        print(self.extensiondir)
+
+        self.fallback_extensiondir = os.path.join(self.parentdir, "extensions")
+
         self.datadir = os.path.join(self.parentdir, "data")
 
         self.resdir = os.path.join(self.parentdir, "resources")
@@ -98,15 +103,19 @@ class ConfigManager:
         self.second_fallback_resdir = Path(self.appdir).absolute() / "resources"
 
         try:
-            os.makedirs(self.datadir, exist_ok=True)
+            Path(self.datadir).mkdir(parents=True, exist_ok=True)
         except Exception as e:
             print(f"Data directory invalid: {e}")
 
         try:
-            # creates the extensions directory next to executable
-            os.makedirs(self.extensionsdir, exist_ok=True)
+            Path(self.extensiondir).mkdir(parents=True, exist_ok=True)
         except Exception as e:
-            print(f"Extensions failed: {e}")
+            print(f"Extensions directory invalid: {e}")
+            try:
+                # fallback
+                Path(self.fallback_extensiondir).mkdir(parents=True, exist_ok=True)
+            except Exception as e:
+                print(f"Extensions failed: {e}")
 
     def setup_extensions(self):
         # sets up the extension API & loads extensions

--- a/src/biscuit/events.py
+++ b/src/biscuit/events.py
@@ -277,3 +277,24 @@ class EventManager(GUIManager, ConfigManager):
                 )
 
         self.statusbar.toggle_editmode(False)
+
+    def log_error(self, message: str) -> None:
+        self.logger.error(message)
+        self.notifications.error(
+            message, actions=[("Show logs", self.commands.show_logs)]
+        )
+
+    def log_info(self, message: str) -> None:
+        self.logger.info(message)
+        self.notifications.info(
+            message, actions=[("Show logs", self.commands.show_logs)]
+        )
+
+    def log_warning(self, message: str) -> None:
+        self.logger.warning(message)
+        self.notifications.warning(
+            message, actions=[("Show logs", self.commands.show_logs)]
+        )
+
+    def log_trace(self, message: str) -> None:
+        self.logger.trace(message)

--- a/src/biscuit/views/extensions/extension.py
+++ b/src/biscuit/views/extensions/extension.py
@@ -35,7 +35,7 @@ class ExtensionGUI(Frame):
         self.data = data
         self.name = name
         self.filename = data[0]
-        self.file = os.path.join(self.base.extensionsdir, data[0])
+        self.file = os.path.join(self.base.extensiondir, data[0])
         self.author = data[1]
         self.description = data[2][:50] + "..." if len(data[2]) > 30 else data[2]
 


### PR DESCRIPTION
fix #427 

- store extensions in `~/.biscuit/extensions`s to 
- fallbacks to the executable basedir