### PR TITLE
Extension Search bar implementation

### DIFF
--- a/src/biscuit/extensions/extensions.py
+++ b/src/biscuit/extensions/extensions.py
@@ -135,11 +135,14 @@ class ExtensionManager:
             except:
                 ...
 
-        for name, data in self.fetched.items():
-            # More complex logic can be used using RegEx
-            if search_string in name:
+        if not search_string:
+            for name, data in self.fetched.items():
                 self.fetch_queue.put((name, data))
-    
+        else:
+            for name, data in self.fetched.items():
+                if search_string.lower() in name.lower():
+                    self.fetch_queue.put((name, data))
+
     def fetch_extensions(self) -> None:
         """Fetch extensions from Extensions repository."""
 

--- a/src/biscuit/extensions/extensions.py
+++ b/src/biscuit/extensions/extensions.py
@@ -110,6 +110,36 @@ class ExtensionManager:
         with self.extensions_lock:
             threading.Thread(target=self.fetch_extensions, daemon=True).start()
 
+    def fetch_searched_extensions(self, search_string) -> None:
+        """Fetch extensions whose name matches the search_string from Extensions repository."""
+
+        response = None
+        try:
+            response = requests.get(self.list_url)
+        except Exception:
+            pass
+
+        # FAIL - network error
+        if not response or response.status_code != 200:
+            try:
+                self.base.extensions_view.results.show_placeholder()
+            except:
+                ...
+            return
+
+        self.fetched = json.loads(response.text)
+        # SUCCESS
+        if self.fetched:
+            try:
+                self.base.extensions_view.results.show_content()
+            except:
+                ...
+
+        for name, data in self.fetched.items():
+            # More complex logic can be used using RegEx
+            if search_string in name:
+                self.fetch_queue.put((name, data))
+    
     def fetch_extensions(self) -> None:
         """Fetch extensions from Extensions repository."""
 

--- a/src/biscuit/views/extensions/extensions.py
+++ b/src/biscuit/views/extensions/extensions.py
@@ -29,6 +29,10 @@ class Extensions(SideBarView):
         self.add_action(Icons.FILTER, self.results.toggle_installed)
         self.add_action(Icons.REFRESH, self.results.refresh)
         self.add_action(Icons.SEARCH, self.results.search)
+        self.searchbox.bind('<Return>', lambda e:self.results.search()) # Bind ENTER KEY PRESS TO Search Function
+        # Error faced & Reason for using Lambda:
+        # # https://stackoverflow.com/questions/23842770/python-function-takes-1-positional-argument-but-2-were-given-how
+
         # self.add_action(Icons.CLEAR_ALL, self.results.clear)
 
     def initialize(self) -> None:

--- a/src/biscuit/views/extensions/extensions.py
+++ b/src/biscuit/views/extensions/extensions.py
@@ -28,6 +28,7 @@ class Extensions(SideBarView):
         self.add_item(self.results)
         self.add_action(Icons.FILTER, self.results.toggle_installed)
         self.add_action(Icons.REFRESH, self.results.refresh)
+        self.add_action(Icons.SEARCH, self.results.search)
         # self.add_action(Icons.CLEAR_ALL, self.results.clear)
 
     def initialize(self) -> None:

--- a/src/biscuit/views/extensions/results.py
+++ b/src/biscuit/views/extensions/results.py
@@ -48,6 +48,7 @@ class Results(SideBarViewItem):
         self.placeholder = ExtensionsPlaceholder(self)
         self.extension_list = ExtensionsList(self.content)
         self.extension_list.pack(fill=tk.BOTH, expand=True)
+        self.master = master
 
         self.filter_installed = False
 
@@ -105,3 +106,11 @@ class Results(SideBarViewItem):
     def toggle_installed(self) -> None:
         self.filter_installed = not self.filter_installed
         self.refresh()
+
+    def search(self) -> None:
+        if self.base.testing:
+            return
+
+        self.clear()
+        self.update_idletasks()
+        self.manager.fetch_searched_extensions(self.master.searchbox.get())


### PR DESCRIPTION
Hi @tomlin7 ,

This closes Issue #409.

I've opted for a simple search logic that returns exact matches. Also searching for an empty string would give you the complete (initial) string as well.

Search feature can be triggered either by pressing the `SEARCH` icon in the top right (beside the `REFRESH` icon), or by pressing `<ENTER>` key after typing.