### PR TITLE
Update settings editor to use sqlite3

### DIFF
--- a/src/biscuit/settings/config.py
+++ b/src/biscuit/settings/config.py
@@ -1,5 +1,5 @@
 import os
-
+import sqlite3
 import toml
 
 from .theme.catppuccin_mocha import CatppuccinMocha
@@ -21,6 +21,19 @@ class Config:
         self.auto_save_enabled = False
         self.auto_save_timer_ms = 10000
 
+        self.db_path = os.path.join(self.base.datadir, "settings.db")
+        self.db = sqlite3.connect(self.db_path)
+        self.cursor = self.db.cursor()
+
+        self.cursor.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS settings (
+                key TEXT PRIMARY KEY NOT NULL,
+                value TEXT
+            );
+            """
+        )
+
     def get_config_path(self, relative_path: str) -> str:
         """Get the absolute path to the resource
 
@@ -36,6 +49,50 @@ class Config:
         return config
 
     def load_data(self) -> None:
-        # TODO testing
-        self.theme = GruvboxDark()
-        self.font = (self.config["font"], self.config["font_size"])
+        self.cursor.execute("SELECT value FROM settings WHERE key='theme'")
+        theme = self.cursor.fetchone()
+        if theme:
+            self.theme = theme[0]
+
+        self.cursor.execute("SELECT value FROM settings WHERE key='font'")
+        font = self.cursor.fetchone()
+        if font:
+            self.font = font[0]
+
+        self.cursor.execute("SELECT value FROM settings WHERE key='uifont'")
+        uifont = self.cursor.fetchone()
+        if uifont:
+            self.uifont = uifont[0]
+
+        self.cursor.execute("SELECT value FROM settings WHERE key='auto_save_enabled'")
+        auto_save_enabled = self.cursor.fetchone()
+        if auto_save_enabled:
+            self.auto_save_enabled = auto_save_enabled[0]
+
+        self.cursor.execute("SELECT value FROM settings WHERE key='auto_save_timer_ms'")
+        auto_save_timer_ms = self.cursor.fetchone()
+        if auto_save_timer_ms:
+            self.auto_save_timer_ms = auto_save_timer_ms[0]
+
+    def save_data(self) -> None:
+        self.cursor.execute(
+            "INSERT OR REPLACE INTO settings (key, value) VALUES ('theme', ?)",
+            (self.theme,),
+        )
+        self.cursor.execute(
+            "INSERT OR REPLACE INTO settings (key, value) VALUES ('font', ?)",
+            (self.font,),
+        )
+        self.cursor.execute(
+            "INSERT OR REPLACE INTO settings (key, value) VALUES ('uifont', ?)",
+            (self.uifont,),
+        )
+        self.cursor.execute(
+            "INSERT OR REPLACE INTO settings (key, value) VALUES ('auto_save_enabled', ?)",
+            (self.auto_save_enabled,),
+        )
+        self.cursor.execute(
+            "INSERT OR REPLACE INTO settings (key, value) VALUES ('auto_save_timer_ms', ?)",
+            (self.auto_save_timer_ms,),
+        )
+        self.db.commit()

--- a/src/biscuit/settings/editor/editor.py
+++ b/src/biscuit/settings/editor/editor.py
@@ -1,4 +1,5 @@
 import tkinter as tk
+import sqlite3
 
 from biscuit.common.ui import Button, Frame, ScrollableFrame
 from biscuit.editor import BaseEditor
@@ -45,6 +46,7 @@ class SettingsEditor(BaseEditor):
     def add_sections(self):
         self.add_commonly_used()
         self.add_text_editor()
+        self.load_settings()
 
     def add_commonly_used(self):
         """Add commonly used settings to the settings editor"""
@@ -98,3 +100,38 @@ class SettingsEditor(BaseEditor):
     def show_no_results(self):
         """Show no results found message in the settings editor"""
         ...
+
+    def load_settings(self):
+        """Load settings from the config manager and update the editor state"""
+        config = self.base.settings.config
+        config.load_data()
+
+        for section in self.sections:
+            for item in section.items:
+                if isinstance(item, DropdownItem):
+                    item.var.set(config.get(item.name, item.var.get()))
+                elif isinstance(item, IntegerItem):
+                    item.entry.delete(0, tk.END)
+                    item.entry.insert(0, config.get(item.name, item.entry.get()))
+                elif isinstance(item, StringItem):
+                    item.entry.delete(0, tk.END)
+                    item.entry.insert(0, config.get(item.name, item.entry.get()))
+                elif isinstance(item, CheckboxItem):
+                    item.var.set(config.get(item.name, item.var.get()))
+
+    def save_settings(self):
+        """Save settings from the editor state to the config manager"""
+        config = self.base.settings.config
+
+        for section in self.sections:
+            for item in section.items:
+                if isinstance(item, DropdownItem):
+                    config.set(item.name, item.var.get())
+                elif isinstance(item, IntegerItem):
+                    config.set(item.name, item.entry.get())
+                elif isinstance(item, StringItem):
+                    config.set(item.name, item.entry.get())
+                elif isinstance(item, CheckboxItem):
+                    config.set(item.name, item.var.get())
+
+        config.save_data()

--- a/src/biscuit/settings/settings.py
+++ b/src/biscuit/settings/settings.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import sqlite3
 import tkinter as tk
 import tkinter.font as tkfont
 import typing
@@ -33,8 +34,6 @@ class Formattable(str):
         return super().format(f"{default}{term}")
 
 
-# TODO: functional settings editor
-# TODO: load/store config in sqlite3 db
 class Settings:
     """Settings for the application
 
@@ -128,6 +127,8 @@ class Settings:
 
         self.symbols_actionset = ActionSet("Go to symbol in editor", "@", [])
         self.base.palette.register_actionset(lambda: self.symbols_actionset)
+
+        self.config.load_data()
 
     @property
     def actionset(self):


### PR DESCRIPTION
Fixes #451

Add functionality to update config manager state and store settings using sqlite3 in the settings editor.

* **Config Manager (`src/biscuit/settings/config.py`):**
  - Add methods to save and load settings from sqlite3.
  - Update `__init__` method to initialize sqlite3 database in `datadir`.
  - Update `load_data` method to load settings from sqlite3.

* **Settings Editor (`src/biscuit/settings/editor/editor.py`):**
  - Add methods to save and load settings from sqlite3.
  - Update `add_sections` method to load settings from config manager.

* **Settings (`src/biscuit/settings/settings.py`):**
  - Update `Settings` class to use sqlite3 for configuration.
  - Update `late_setup` method to load settings from sqlite3.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tomlin7/biscuit/issues/451?shareId=0b1aebdb-f312-4451-8eff-5e3c54fb1fb3).