### PR TITLE
fix: Corrected start_index for indent_guide tagging

### DIFF
--- a/src/biscuit/editor/text/text.py
+++ b/src/biscuit/editor/text/text.py
@@ -323,7 +323,7 @@ class Text(BaseText):
 
     def add_indent_guide(self, line_number: int, indent_level: int) -> None:
         for level in range(indent_level):
-            start_index = f"{line_number}.{level * self.tab_spaces - 1}"
+            start_index = f"{line_number}.{level * self.tab_spaces}"
             end_index = f"{line_number}.{level * self.tab_spaces + 1}"
             self.tag_add(
                 (


### PR DESCRIPTION
fix: https://github.com/tomlin7/biscuit/issues/413

fixes by correctly assigning `start_index` in the `add_indent_guide` function