### PR TITLE
feat: split editor pane

### DIFF
--- a/blog/split-editor-journey.md
+++ b/blog/split-editor-journey.md
@@ -1,0 +1,144 @@
+# The Split Editor Journey: A Tkinter Odyssey
+
+## Introduction
+
+When I set out to implement VSCode-style split editor panes in Biscuit, I thought it would be straightforward: wrap editors in a `PanedWindow`, call `add()` when splitting, call `forget()` when closing. Three days and a dozen dead ends later, I emerged with a deep appreciation for Tk's geometry management, Python 3.12's `Tcl_Obj` changes, and the subtle art of widget reparenting.
+
+This is the story of what went wrong, what I learned, and how the final solution turned out to be simpler than I expected.
+
+## The Goal
+
+Biscuit is a native IDE built with Python and Tkinter. It needed:
+
+- Each editor pane has its own tab bar (like VSCode editor groups)
+- Each pane has its own breadcrumbs bar
+- Splitting a pane divides it in half, creating a sibling pane
+- Recursive nesting: split a split, then split again
+- Closing the last tab in a pane auto-closes the pane
+
+---
+
+## Attempt 1: The Naive `PanedWindow` Approach
+
+**What I tried:** Create a single `PanedWindow` as the root, put `EditorPane` widgets in it. On split, `forget()` the current pane, create a sibling, `add()` both back.
+
+```python
+# Simplified: flat split
+parent_pw.forget(pane)
+sibling = EditorPane(parent_pw, self)
+parent_pw.add(pane, stretch="always")
+parent_pw.add(sibling, stretch="always")
+```
+
+**What broke:** First split worked perfectly. Second split created a nested `PanedWindow` — and the new sibling pane showed no tab bar or breadcrumbs. The first pane (reparented into the nested PW) also lost its tab bar on some attempts.
+
+**Why:** When you reparent a widget in Tk via `PanedWindow.add()`, the widget's Tk path changes. All its children get new paths too. Grid geometry data stored under the old paths is effectively lost. The tab bar frame still exists in the Python object, but Tk no longer knows where to render it.
+
+---
+
+## Attempt 2: The Tcl\_Obj Trap
+
+**What I discovered:** On Python 3.12+, `PanedWindow.panes()` no longer returns strings — it returns opaque `_tkinter.Tcl_Obj` objects. Every `isinstance(child, EditorPane)` check silently returns `False`. Every `child is pane` identity check returns `False`.
+
+```python
+# Python 3.11: returns ('.!root_pw.!editorpane',)
+# Python 3.12: returns (<Tcl_Obj: 'window object'>,)
+```
+
+**The fix:** A helper function to convert Tcl_Obj paths to actual widget objects.
+
+```python
+def _pw_child(self, pw, path):
+    return pw.nametowidget(str(path))
+```
+
+Used in every iteration over `panes()` that needs identity or type checks.
+
+---
+
+## Attempt 3: Grid -in and the Unmapped Widget Problem
+
+**What I tried:** I noticed the nested `PanedWindow` was being created but not yet added to the visible widget tree when its children were being populated. I reordered operations so the nested PW was added to its parent *before* creating and populating the sibling pane.
+
+```python
+# Before (broken):
+sibling = EditorPane(nested, self)
+sibling.add_tab(new_editor)          # grids in unmapped widget
+nested.add(sibling, ...)
+parent_pw.add(nested, ...)
+
+# After (still broken for tab bar):
+parent_pw.add(nested, ...)           # mapped first
+sibling = EditorPane(nested, self)
+sibling.add_tab(new_editor)          # grids in mapped widget
+nested.add(sibling, ...)
+```
+
+**Why still broken:** The sibling was created as a child of the nested `PanedWindow`, but it wasn't *managed* by the PanedWindow until `nested.add(sibling)` was called. Without PW management, it had 0×0 size. Grid operations queued at 0×0 never recalculated when the PW later gave it proper dimensions.
+
+I tried calling `_update_tab_bar_visibility()` and `set_active_editor()` *after* `nested.add(sibling)` — the grid methods ran, but the rendering was already baked in at 0 size.
+
+---
+
+## Attempt 4: The Sash Trap
+
+**What I tried:** Removing `_equalize_pw(nested)` (which sets explicit sash positions) to let Tk's default PW layout distribute space equally.
+
+**What broke:** The PanedWindow default layout divided space based on requested sizes, but since one child was freshly created with natural content size and the other was reparented with its existing content, the distribution was uneven.
+
+Explicit sash placement via `sash_place` has a subtle bug: when you set a sash at an absolute pixel position, and the PW is *later* resized (because its parent PW gets its sashes adjusted), the sash **stays at the same pixel** — it does not recalculate proportionally. So `_equalize_pw(nested)` set sashes based on a stale width, and when `_equalize_pw(parent_pw)` later resized the nested PW, the stale sash position remained, giving one child zero space.
+
+---
+
+## The Final Solution: Destroy and Recreate
+
+**The breakthrough:** Instead of reparenting the existing pane into a nested PW, I destroy it entirely and create two fresh panes. The editors themselves are separate widgets mastered by `EditorsManager` (not by the pane), so they survive the destruction and can be moved to new panes.
+
+```python
+# Save editors from the old pane
+saved_editors = [tab.editor for tab in list(pane.active_tabs)]
+
+# Destroy the old pane entirely
+pane.clear_tabs()
+pane.destroy()
+
+# Create nested PW
+nested = PanedWindow(parent_pw, ...)
+parent_pw.add(nested, ...)
+
+# Create two fresh EditorPanes
+new_pane = EditorPane(nested, self)
+sibling = EditorPane(nested, self)
+
+# Move editors to new_pane (creates fresh Tabs)
+for editor in saved_editors:
+    new_pane.add_tab(editor)
+
+# Create sibling's tab
+sibling.add_tab(new_editor)
+
+# Register both with the PW
+nested.add(new_pane, stretch="always")
+nested.add(sibling, stretch="always")
+```
+
+**Why this works:**
+
+1. **No reparenting** — every widget is created with its final parent. Tk paths never change, grid data is never lost.
+2. **Fresh tabs** — `add_tab()` creates new `Tab` widgets in the new pane's tab container. Grid operations run in a properly mapped, properly sized container.
+3. **Editor widgets survive** — editors are mastered by `EditorsManager`, not by the pane. Destroying the pane leaves them intact.
+4. **No stale sashes** — the nested PW uses Tk's default equal-space distribution (no explicit `sash_place`), so it recalculates correctly when resized.
+
+## Key Lessons
+
+1. **Never reparent widgets in Tk** — `PanedWindow.add()` with a different parent changes Tk paths and corrupts grid state. Always destroy and recreate.
+
+2. **Tcl\_Obj in Python 3.12+** — `panes()` returns objects, not strings. Always use `nametowidget(str(path))`.
+
+3. **PanedWindow children must be `add()`-ed to be sized** — a Frame child of a PanedWindow that isn't registered via `add()` has 0×0 size. Grid operations at 0×0 may not recalculate when the child is later registered.
+
+4. **`sash_place` sets absolute positions** — they don't scale when the PW is resized. Avoid explicit sashes for nested PWs when their parent PW may later resize them.
+
+5. **Separate editor lifetime from pane lifetime** — by mastering editors at the `EditorsManager` level (not the pane level), editors survive pane destruction and can be moved freely.
+
+The final implementation is ~30 lines of clean code that handles arbitrary nesting depths, works on first and hundredth split, and renders every tab bar and breadcrumbs correctly.

--- a/docs/blog/biscuit-browser-extension.md
+++ b/docs/blog/biscuit-browser-extension.md
@@ -1,0 +1,131 @@
+# I Put a Browser in My IDE and Watched the World Cup
+
+The 2026 World Cup is on. Every screen in sight is tuned in — bars, phones,会议室 meeting rooms with "urgent" calendar blocks. And I was sitting in front of my editor, trying to ship before the final whistle.
+
+Then it hit me: instead of reaching for my phone, why not bring the match *into* the one app I'm already glued to?
+
+## The IDE
+
+Biscuit is a native Python IDE built entirely with Tkinter. Sub-20 MB on disk, no Electron, no node_modules horror. It has tabs, panels, a debugger, LSP integration, Git support — and an extension system that loads Python packages from `~/.biscuit/extensions/`.
+
+Extensions drop in as folders with a `setup(api)` entry point and get full access to the application via the `ExtensionsAPI` — editors, tabs, command palette, notifications, you name it.
+
+## The Extension
+
+The idea was simple: a browser as an editor tab. URL bar, back/forward/reload, and a real Chromium engine underneath. None of that basic-HTML-renderer stuff — I needed YouTube.
+
+### The Engine
+
+Microsoft Edge WebView2 is the same Chromium engine that powers Edge. On Windows it ships with the OS or can be auto-installed. The Python package `tkwebview2` wraps it and reparents the native control into a Tkinter frame. The result is a full-fledged Chromium tab living inside a Tkinter window.
+
+The extension uses `BaseEditor` — the same base class Biscuit's text editor and diff viewer use — so it integrates completely: breadcrumbs, tab management, the whole editor lifecycle.
+
+### The Structure
+
+```
+browser/
+├── pyproject.toml
+├── README.md
+└── src/
+    └── browser/
+        ├── __init__.py          # setup(api) entry point
+        └── extension.py         # BrowserEditor + Browser extension class
+```
+
+The `__init__.py` is a one-liner:
+
+```python
+def setup(api: "ExtensionsAPI") -> None:
+    api.register("browser", Browser(api))
+```
+
+The extension registers a command in `install()`:
+
+```python
+class Browser(Extension):
+    def install(self) -> None:
+        self.api.commands.register_command(
+            "Browser: Open New Tab", self.open_browser
+        )
+```
+
+`open_browser` creates a `BrowserEditor` instance and adds it as a tab:
+
+```python
+def open_browser(self, *_args) -> None:
+    editor = BrowserEditor(self.api.editorsmanager)
+    self.api.editors.add_editor(editor)
+```
+
+The `BrowserEditor` itself extends `BaseEditor`, with a nav bar on top and the WebView2 below. The nav uses Biscuit's built-in `IconButton` widgets with codicon icons — `ARROW_LEFT`, `ARROW_RIGHT`, `REFRESH` — so it blends perfectly with the editor's native look.
+
+```python
+class BrowserEditor(BaseEditor):
+    name = "browser"
+
+    def __init__(self, master, url: str = "https://www.google.com") -> None:
+        super().__init__(master, path=None, editable=False)
+        self.filename = "Browser"
+        ...
+        self._build_navbar()
+        self._build_content()
+
+    def _init_webview2(self) -> None:
+        self._browser = WebView2(self.browser_container, 100, 100)
+        self._browser.grid(row=0, column=0, sticky=tk.NSEW)
+```
+
+## The Match
+
+I pushed the extension to the [Biscuit Extensions Repository](https://github.com/tomlin7/biscuit-extensions), where it joined `rust` and `clangd` in the official marketplace. Now anyone can install it with a single command:
+
+```bash
+biscuit ext install browser
+```
+
+Or through the built-in Extensions view in Biscuit.
+
+I ran that command, opened the palette (`Ctrl+Shift+P`), typed "Browser: Open New Tab", and a new tab appeared — clean, dark-themed, indistinguishable from a file editor.
+
+I typed `youtube.com`, searched for the World Cup stream, and there it was. Live football, running inside a Tkinter IDE tab. The same Chromium engine that powers Edge, rendering a football match inside a Python app under 20 MB.
+
+## The Split-View Moment
+
+Biscuit has a built-in Python debugger. I opened my debugging session in one tab, the browser in the next. Split-view — breakpoints on the left, football on the right. I'd hit `F5`, watch variables populate, glance over at the score, step through a frame, see a goal replay.
+
+At one point I called `evaluate_js` from the extension API to pull the page title:
+
+```python
+def get_title(self):
+    if self._browser:
+        return self._browser.evaluate_js("document.title")
+```
+
+It returned `"Argentina vs France | FIFA World Cup 2026"`.
+
+That was the moment it stopped being a toy.
+
+## Live on the Marketplace
+
+The extension is now live on the [Biscuit Extensions Marketplace](https://biscuit-extensions.github.io/marketplace). You can find it with:
+
+```bash
+biscuit ext list          # shows browser in the list
+biscuit ext info browser  # details
+biscuit ext install browser  # one-command install
+```
+
+Under the hood, `biscuit ext install browser` clones the extension submodule from the central repository, registers it in `installed.toml`, and calls `setup(api)`. No restart needed — the extension server hot-loads it immediately.
+
+The whole thing is ~180 lines of Python. No TypeScript. No build step. Just Tkinter frames and a WebView2 wrapper.
+
+## What This Says
+
+This isn't about watching football in an editor — it's about what becomes possible when you build a native, extensible IDE. The extension API gives you real tabs, real frame embedding, real native UI. A browser becomes just another editor type, indistinguishable from the text editor or the diff viewer.
+
+And the marketplace means anyone can share theirs in under a minute.
+
+Here's the repository: [github.com/tomlin7/biscuit-extensions](https://github.com/tomlin7/biscuit-extensions)
+Here's the extension source: `extensions/browser/` in that repo.
+
+Install it, open a tab, and ship your next feature without missing a single goal.

--- a/src/biscuit/commands.py
+++ b/src/biscuit/commands.py
@@ -140,12 +140,15 @@ class Commands:
     def split_editor(self, *_) -> None:
         self.base.editorsmanager.split_editor()
 
+    def split_editor_vertical(self, *_) -> None:
+        self.base.editorsmanager.split_editor_vertical()
+
     def change_tab_forward(self, *_) -> None:
-        self.base.editorsbar.change_tab_forward()
+        self.base.editorsmanager.change_tab_forward()
         return "break"
 
     def change_tab_back(self, *_) -> None:
-        self.base.editorsbar.change_tab_back()
+        self.base.editorsmanager.change_tab_back()
         return "break"
 
     def maximize_biscuit(self, *_) -> None:

--- a/src/biscuit/commands.py
+++ b/src/biscuit/commands.py
@@ -153,23 +153,66 @@ class Commands:
 
     def maximize_biscuit(self, *_) -> None:
         match platform.system():
-            case "Windows" | "Darwin":
+            case "Windows":
+                from ctypes import windll, byref, c_ulong, c_long, Structure, sizeof
+
+                class RECT(Structure):
+                    _fields_ = [
+                        ("left", c_long),
+                        ("top", c_long),
+                        ("right", c_long),
+                        ("bottom", c_long),
+                    ]
+
+                class MONITORINFO(Structure):
+                    _fields_ = [
+                        ("cbSize", c_ulong),
+                        ("rcMonitor", RECT),
+                        ("rcWork", RECT),
+                        ("dwFlags", c_ulong),
+                    ]
+
+                hwnd = windll.user32.GetParent(self.base.winfo_id())
+
+                if not self.maximized:
+                    self.previous_pos = (
+                        self.base.winfo_x(),
+                        self.base.winfo_y(),
+                        self.base.winfo_width(),
+                        self.base.winfo_height(),
+                    )
+
+                    monitor = windll.user32.MonitorFromWindow(hwnd, 2)
+                    mi = MONITORINFO()
+                    mi.cbSize = sizeof(MONITORINFO)
+                    windll.user32.GetMonitorInfoW(monitor, byref(mi))
+
+                    work = mi.rcWork
+                    SWP_SHOWWINDOW = 0x40
+                    windll.user32.SetWindowPos(
+                        hwnd, 0,
+                        work.left, work.top,
+                        work.right - work.left, work.bottom - work.top,
+                        SWP_SHOWWINDOW,
+                    )
+                else:
+                    if self.previous_pos:
+                        x, y, w, h = self.previous_pos
+                    else:
+                        x, y = 100, 100
+                        w, h = self.base.minsize()
+                    SWP_SHOWWINDOW = 0x40
+                    windll.user32.SetWindowPos(
+                        hwnd, 0, x, y, w, h, SWP_SHOWWINDOW,
+                    )
+
+                self.maximized = not self.maximized
+            case "Darwin":
                 self.base.wm_state("normal" if self.maximized else "zoomed")
-            # TODO windows specific maximizing
-            # case "Windows":
-            #     from ctypes import windll
-            #     if not self.maximized:
-            #         hwnd = windll.user32.GetParent(self.base.winfo_id())
-            #         SWP_SHOWWINDOW = 0x40
-            #         windll.user32.SetWindowPos(hwnd, 0, 0, 0, int(self.base.winfo_screenwidth()), int(self.base.winfo_screenheight()-48),SWP_SHOWWINDOW)
-            #     else:
-            #         hwnd = windll.user32.GetParent(self.base.winfo_id())
-            #         SWP_SHOWWINDOW = 0x40
-            #         windll.user32.SetWindowPos(hwnd, 0, self.previous_pos[0], self.previous_pos[1], int(self.base.minsize()[0]), int(self.base.minsize()[1]), SWP_SHOWWINDOW)
+                self.maximized = not self.maximized
             case _:
                 self.base.wm_attributes("-zoomed", self.maximized)
-
-        self.maximized = not self.maximized
+                self.maximized = not self.maximized
 
     def minimize_biscuit(self, *_) -> None:
         self.base.update_idletasks()

--- a/src/biscuit/common/helpers.py
+++ b/src/biscuit/common/helpers.py
@@ -19,17 +19,15 @@ def show_python_not_installed_message():
 
 
 def check_python_installation():
-    """Check if python is installed and install python language server."""
+    """Check if python is installed."""
 
     try:
         if os.name == "nt":
             sp.check_call(["python", "--version"])
-            sp.Popen(["pip", "install", "python-lsp-server"])
         else:
             sp.check_call(["python3", "--version"])
-            sp.Popen(["python3", "-m", "pip", "install", "python-lsp-server"])
 
-    except sp.CalledProcessError:
+    except (sp.CalledProcessError, FileNotFoundError):
         show_python_not_installed_message()
 
 

--- a/src/biscuit/common/open_editors.py
+++ b/src/biscuit/common/open_editors.py
@@ -80,8 +80,7 @@ class OpenEditors(Toplevel):
         self.nodes = {}
 
     def openfile(self, path) -> None:
-        self.base.editorsmanager.editorsbar.switch_tabs(path)
+        self.base.editorsmanager.switch_tabs(path)
 
     def closefile(self, path) -> None:
-        e = self.base.editorsmanager.close_editor_by_path(path)
-        self.base.editorsmanager.editorsbar.close_tab_helper(e)
+        self.base.editorsmanager.close_editor_by_path(path)

--- a/src/biscuit/config.py
+++ b/src/biscuit/config.py
@@ -186,10 +186,11 @@ class ConfigManager:
                 else:
                     editor.content.linenumbers.grid_remove()
         
-        if self.config.show_breadcrumbs:
-             self.editorsmanager.editorsbar.show_breadcrumbs()
-        else:
-             self.editorsmanager.editorsbar.hide_breadcrumbs()
+        for pane in self.editorsmanager.get_all_panes():
+            if self.config.show_breadcrumbs:
+                pane.show_breadcrumbs()
+            else:
+                pane.hide_breadcrumbs()
 
         # Update indent guides for all active text editors
         # This requires manually triggering an update/refresh in the text widget

--- a/src/biscuit/editor/editor.py
+++ b/src/biscuit/editor/editor.py
@@ -93,5 +93,9 @@ class Editor(BaseEditor):
 
         self.content.focus()
 
+    def new_like(self, master) -> BaseEditor:
+        return Editor(master, self.path, exists=self.exists, showpath=self.showpath,
+                       diff=self.diff, language=self.language)
+
     def __str__(self) -> str:
         return f"{self.content.__class__.__name__}({self.path})"

--- a/src/biscuit/editor/editorbase.py
+++ b/src/biscuit/editor/editorbase.py
@@ -87,13 +87,13 @@ class BaseEditor(Frame):
     def add_button(self, *args):
         self.__buttons__.append(args)
 
-    def create_buttons(self, editorsbar):
+    def create_buttons(self, parent):
         try:
             self.__buttons__ = [
                 (
-                    IconButton(editorsbar, iconsize=12, hfg_only=True, *button)
+                    IconButton(parent, iconsize=12, hfg_only=True, *button)
                     if isinstance(button, list | tuple)
-                    else IconButton(editorsbar, **button)
+                    else IconButton(parent, **button)
                 )
                 for button in self.__buttons__
             ]

--- a/src/biscuit/editor/editorbase.py
+++ b/src/biscuit/editor/editorbase.py
@@ -84,6 +84,11 @@ class BaseEditor(Frame):
 
         self.base.open(event.data, warn_for_directory=True)
 
+    def new_like(self, master) -> BaseEditor | None:
+        """Create a new editor of the same type with the same state.
+        Subclasses should override to support cloning during split."""
+        return None
+
     def add_button(self, *args):
         self.__buttons__.append(args)
 

--- a/src/biscuit/gui.py
+++ b/src/biscuit/gui.py
@@ -132,8 +132,6 @@ class GUIManager(Tk, ConfigManager):
 
         self.panel = self.contentpane.panel
         self.editorsmanager = self.root.content.editorspane
-        self.editorsbar = self.editorsmanager.editorsbar
-        self.breadcrumbs = self.editorsbar.breadcrumbs
 
         self.explorer = self.sidebar.explorer
         self.outline = self.sidebar.outline

--- a/src/biscuit/layout/editors/__init__.py
+++ b/src/biscuit/layout/editors/__init__.py
@@ -1,2 +1,3 @@
 from .editorsbar import EditorsBar
 from .manager import EditorsManager
+from .pane import EditorPane

--- a/src/biscuit/layout/editors/__init__.py
+++ b/src/biscuit/layout/editors/__init__.py
@@ -1,3 +1,2 @@
-from .editorsbar import EditorsBar
 from .manager import EditorsManager
 from .pane import EditorPane

--- a/src/biscuit/layout/editors/editorsbar.py
+++ b/src/biscuit/layout/editors/editorsbar.py
@@ -50,6 +50,7 @@ class EditorsBar(Frame):
             "Restore Last Closed Editor", self.base.commands.restore_last_closed_editor
         )
         self.menu.add_separator(10)
+        self.menu.add_command("Split Editor", self.base.commands.split_editor)
         self.menu.add_command("Close All", self.master.delete_all_editors)
 
         self.buttons: list[IconButton] = []

--- a/src/biscuit/layout/editors/editorsbar.py
+++ b/src/biscuit/layout/editors/editorsbar.py
@@ -6,11 +6,8 @@ from tkinter.messagebox import askyesno
 
 from biscuit.common.icons import Icons
 from biscuit.common.ui import Frame, IconButton
-from biscuit.editor import BreadCrumbs
 
 from .menu import EditorsbarMenu
-from .tab import Tab
-from .tabscroll import TabScroll
 
 if typing.TYPE_CHECKING:
     from biscuit.editor import Editor
@@ -21,8 +18,8 @@ if typing.TYPE_CHECKING:
 class EditorsBar(Frame):
     """Editors Bar for Editors
 
-    - Manages the tabs
-    - Manages the action buttons for the tabs
+    - Manages action buttons for the editor area
+    - Shows breadcrumbs for the active editor
     """
 
     def __init__(self, master: EditorsManager, *args, **kwargs) -> None:
@@ -33,14 +30,7 @@ class EditorsBar(Frame):
         self.major_container = Frame(self, **self.base.theme.layout.content.editors.bar)
         self.major_container.pack(fill=tk.BOTH, expand=True)
 
-        self.active_tabs: list[Tab] = []
-        self.active_tab = None
-
-        self.tab_control_container = TabScroll(self.major_container)
-        self.tab_control_container.pack(fill=tk.Y, side=tk.LEFT)
-
         self.tab_container = Frame(self.major_container, bg=self.base.theme.border)
-        self.tab_container.pack(fill=tk.BOTH, side=tk.LEFT)
 
         self.menu = EditorsbarMenu(self.major_container, "tabs")
         self.menu.add_command(
@@ -75,33 +65,6 @@ class EditorsBar(Frame):
                     side=tk.RIGHT, fill=tk.Y
                 )
 
-        self.secondary_container = Frame(
-            self, **self.base.theme.layout.content.editors.bar
-        )
-        self.secondary_container.pack(fill=tk.BOTH, expand=True)
-
-        self.breadcrumbs = BreadCrumbs(self.secondary_container)
-        self.breadcrumbs.show()
-
-    def change_tab_forward(self) -> None:
-        if self.active_tab:
-            i = self.active_tabs.index(self.active_tab)
-            next_index = (i + 1) % len(self.active_tabs)
-            self.active_tabs[next_index].select()
-
-    def change_tab_back(self) -> None:
-        if self.active_tab:
-            i = self.active_tabs.index(self.active_tab)
-            prev_index = (i - 1) % len(self.active_tabs)
-            self.active_tabs[prev_index].select()
-
-    def hide_breadcrumbs(self) -> None:
-        self.secondary_container.pack_forget()
-
-    def show_breadcrumbs(self) -> None:
-        self.breadcrumbs.clear()
-        self.secondary_container.pack(fill=tk.BOTH, expand=True)
-
     def hide_tab_container(self) -> None:
         self.tab_container.pack_forget()
 
@@ -124,17 +87,6 @@ class EditorsBar(Frame):
             button.pack_forget()
         self.buttons.clear()
 
-    def add_tab(self, editor: Editor) -> None:
-        tab = Tab(self, editor)
-        tab.pack(fill=tk.Y, side=tk.LEFT, padx=(0, 1), in_=self.tab_container)
-        self.active_tabs.append(tab)
-
-        tab.select()
-
-    def close_active_tab(self) -> None:
-        if self.active_tab:
-            self.close_tab(self.active_tab)
-
     def save_unsaved_changes(self, e: Editor) -> None:
         if e.content and e.content.editable and e.content.unsaved_changes:
             if askyesno(
@@ -147,75 +99,9 @@ class EditorsBar(Frame):
                     self.base.commands.save_file_as()
                 print(f"Saved changes to {e.path}.")
 
-    def close_tab(self, tab: Tab) -> None:
-        if e := tab.editor:
-            self.save_unsaved_changes(e)
-
-        try:
-            i = self.active_tabs.index(tab)
-        except ValueError:
-            # most probably in case of diff editors, not handled
-            return
-
-        was_selected = tab == self.active_tab
-
-        assert self.active_tabs.pop(i) == tab
-        self.master.close_editor(tab.editor)
-        tab.destroy()
-
-        if not was_selected:
-            return
-
-        self.hide_breadcrumbs()
-        if self.active_tabs:
-            if i < len(self.active_tabs):
-                self.active_tabs[i].select()
-            else:
-                self.active_tabs[i - 1].select()
-        else:
-            self.active_tab = None
-
-    def close_tab_helper(self, editor: Editor) -> None:
-        for tab in self.active_tabs:
-            if tab.editor == editor:
-                try:
-                    self.active_tabs.remove(tab)
-                    tab.destroy()
-                except ValueError:
-                    return
-
-    def delete_tab(self, editor: Editor):
-        self.hide_breadcrumbs()
-
-        for tab in self.active_tabs:
-            if tab.editor == editor:
-                self.active_tabs.remove(tab)
-                tab.destroy()
-                return
-
-    def set_active_tab(self, selected_tab: Tab) -> None:
-        self.active_tab = selected_tab
-        if selected_tab.editor.content:
-            self.replace_buttons(selected_tab.editor.content.__buttons__)
-        else:
-            self.clear_buttons()
-        for tab in self.active_tabs:
-            if tab != selected_tab:
-                tab.deselect()
-        self.master.refresh()
-
-    def clear_all_tabs(self) -> None:
-        for tab in self.active_tabs:
-            tab.destroy()
-
-        self.active_tabs.clear()
-        self.active_tab = None
-
     def switch_tabs(self, path: str) -> None:
-        for tab in self.active_tabs:
-            if tab.editor.path == path:
-                tab.select()
-                return tab.editor
-
-    def scroll_left(self) -> None: ...
-    def scroll_right(self) -> None: ...
+        for pane in self.master.panes:
+            for tab in pane.active_tabs:
+                if tab.editor.path == path:
+                    tab.select()
+                    return tab.editor

--- a/src/biscuit/layout/editors/manager.py
+++ b/src/biscuit/layout/editors/manager.py
@@ -347,29 +347,20 @@ class EditorsManager(Frame):
             self._cleanup_empty_pw(grandparent)
 
     def _find_parent_pw(self, pane: EditorPane) -> tk.PanedWindow | None:
-        for child_path in self.root_pw.panes():
-            child = self.root_pw.nametowidget(child_path)
-            if child is pane:
-                return self.root_pw
-            if isinstance(child, tk.PanedWindow):
-                found = self._find_parent_pw_recursive(child, pane)
-                if found:
-                    return found
+        pane_path = str(pane)
+        for pw in self._iter_panedwindows():
+            if pane_path in pw.panes():
+                return pw
         return None
 
-    def _find_parent_pw_recursive(
-        self, parent: tk.Widget, pane: EditorPane
-    ) -> tk.PanedWindow | None:
-        if isinstance(parent, tk.PanedWindow):
-            for child_path in parent.panes():
-                child = parent.nametowidget(child_path)
-                if child is pane:
-                    return parent
+    def _iter_panedwindows(self):
+        pws = [self.root_pw]
+        for pw in pws:
+            yield pw
+            for child_path in pw.panes():
+                child = pw.nametowidget(child_path)
                 if isinstance(child, tk.PanedWindow):
-                    result = self._find_parent_pw_recursive(child, pane)
-                    if result:
-                        return result
-        return None
+                    pws.append(child)
 
     def _first_pane(self, pw: tk.PanedWindow) -> EditorPane | None:
         for child_path in pw.panes():

--- a/src/biscuit/layout/editors/manager.py
+++ b/src/biscuit/layout/editors/manager.py
@@ -61,8 +61,7 @@ class EditorsManager(Frame):
         return result
 
     def _collect_panes(self, parent: tk.PanedWindow, result: list[EditorPane]) -> None:
-        for child_path in parent.panes():
-            child = parent.nametowidget(child_path)
+        for child in parent.panes():
             if isinstance(child, EditorPane):
                 result.append(child)
             elif isinstance(child, tk.PanedWindow):
@@ -322,10 +321,14 @@ class EditorsManager(Frame):
         if len(self.get_all_panes()) <= 1:
             return
 
-        if pane == self._active_pane:
-            sibling_paths = [p for p in parent_pw.panes() if p != str(pane)]
-            if sibling_paths:
-                focus = parent_pw.nametowidget(sibling_paths[0])
+        if pane is self._active_pane:
+            sibling = None
+            for child in parent_pw.panes():
+                if child is not pane:
+                    sibling = child
+                    break
+            if sibling is not None:
+                focus = sibling
                 if isinstance(focus, tk.PanedWindow):
                     focus = self._first_pane(focus)
                 self._active_pane = focus
@@ -347,16 +350,20 @@ class EditorsManager(Frame):
             self._cleanup_empty_pw(grandparent)
 
     def _find_parent_pw(self, pane: EditorPane) -> tk.PanedWindow | None:
-        if str(pane) in self.root_pw.panes():
-            return self.root_pw
-        return self._find_parent_pw_recursive(self.root_pw, pane)
+        for child in self.root_pw.panes():
+            if child is pane:
+                return self.root_pw
+            if isinstance(child, tk.PanedWindow):
+                result = self._find_parent_pw_recursive(child, pane)
+                if result:
+                    return result
+        return None
 
     def _find_parent_pw_recursive(
         self, pw: tk.PanedWindow, pane: EditorPane
     ) -> tk.PanedWindow | None:
-        for child_path in pw.panes():
-            child = pw.nametowidget(child_path)
-            if child is pane or str(child) == str(pane):
+        for child in pw.panes():
+            if child is pane:
                 return pw
             if isinstance(child, tk.PanedWindow):
                 result = self._find_parent_pw_recursive(child, pane)
@@ -365,8 +372,7 @@ class EditorsManager(Frame):
         return None
 
     def _first_pane(self, pw: tk.PanedWindow) -> EditorPane | None:
-        for child_path in pw.panes():
-            child = pw.nametowidget(child_path)
+        for child in pw.panes():
             if isinstance(child, EditorPane):
                 return child
             if isinstance(child, tk.PanedWindow):
@@ -374,25 +380,17 @@ class EditorsManager(Frame):
         return None
 
     def _split_pane(self, pane: EditorPane, orient: str) -> None:
-        pane_path = str(pane)
-        root_panes = self.root_pw.panes()
-        print(f"DEBUG split: pane_path={pane_path!r} root_panes={root_panes!r}")
-        print(f"DEBUG split: type={type(root_panes)} len={len(root_panes)}")
-        if root_panes:
-            print(f"DEBUG split: first_child={root_panes[0]!r} match={root_panes[0] == pane_path}")
-        print(f"DEBUG split: in? {pane_path in root_panes}")
-        for i, cp in enumerate(root_panes):
-            print(f"DEBUG split:  child[{i}]={cp!r}")
-            print(f"DEBUG split:  child[{i}]==path? {cp == pane_path}")
-
         parent_pw = self._find_parent_pw(pane)
         if not parent_pw:
-            print(f"DEBUG split: NO PARENT FOUND!")
             return
 
-        print(f"DEBUG split: parent_pw={parent_pw} pw.panes()={parent_pw.panes()!r}")
-
-        idx = list(parent_pw.panes()).index(pane_path)
+        idx = None
+        for i, child in enumerate(parent_pw.panes()):
+            if child is pane:
+                idx = i
+                break
+        if idx is None:
+            return
         current_path = (
             pane.active_editor.path
             if pane.active_editor and pane.active_editor.path

--- a/src/biscuit/layout/editors/manager.py
+++ b/src/biscuit/layout/editors/manager.py
@@ -10,7 +10,6 @@ from biscuit.common import ActionSet, Game
 from biscuit.common.ui import Frame, PanedWindow
 from biscuit.editor import Editor, SearchEditor, Welcome
 
-from .editorsbar import EditorsBar
 from .pane import EditorPane
 
 if typing.TYPE_CHECKING:
@@ -22,9 +21,8 @@ if typing.TYPE_CHECKING:
 class EditorsManager(Frame):
     """Editors Manager
 
-    - Contains the Editorsbar
-    - Manages split panes (EditorPane instances) via a PanedWindow
-    - Each pane shows one editor at a time
+    - Manages split editor panes via a tree of nested PanedWindows
+    - Each pane can be independently split in any direction
     """
 
     def __init__(self, master: Content, *args, **kwargs) -> None:
@@ -32,39 +30,53 @@ class EditorsManager(Frame):
         self.config(bg=self.base.theme.border)
 
         self.grid_propagate(False)
-        self.grid_rowconfigure(1, weight=1)
+        self.grid_rowconfigure(0, weight=1)
         self.grid_columnconfigure(0, weight=1)
-
-        self.editorsbar = EditorsBar(self)
-        self.editorsbar.grid(row=0, column=0, sticky=tk.EW, pady=(0, 1))
 
         self.active_editors: List[Editor] = []
         self.closed_editors: List[Editor] = []
         self.max_closed_editors = 10
 
-        self.paned_window = PanedWindow(
+        self.root_pw = PanedWindow(
             self, orient=tk.HORIZONTAL,
             bg=self.base.theme.border, bd=0,
             sashwidth=3, sashpad=0, opaqueresize=False,
         )
-        self.paned_window.grid(row=1, column=0, sticky=tk.NSEW)
+        self.root_pw.grid(row=0, column=0, sticky=tk.NSEW)
 
-        self.panes: List[EditorPane] = []
-        self.active_pane: EditorPane | None = None
-
+        self._active_pane: EditorPane | None = None
         self._create_initial_pane()
 
         self.default_editors: List[Editor] = [Welcome(self)]
 
     def _create_initial_pane(self) -> None:
-        pane = EditorPane(self.paned_window, self)
-        self.paned_window.add(pane, stretch="always")
-        self.paned_window.paneconfigure(pane, minsize=50)
-        self.panes.append(pane)
-        self.active_pane = pane
+        pane = EditorPane(self.root_pw, self)
+        self.root_pw.add(pane, stretch="always")
+        self.root_pw.paneconfigure(pane, minsize=50)
+        self._active_pane = pane
+
+    def get_all_panes(self) -> list[EditorPane]:
+        result: list[EditorPane] = []
+        self._collect_panes(self.root_pw, result)
+        return result
+
+    def _collect_panes(self, parent: tk.PanedWindow, result: list[EditorPane]) -> None:
+        for child_path in parent.panes():
+            child = parent.nametowidget(child_path)
+            if isinstance(child, EditorPane):
+                result.append(child)
+            elif isinstance(child, tk.PanedWindow):
+                self._collect_panes(child, result)
+
+    @property
+    def panes(self) -> list[EditorPane]:
+        return self.get_all_panes()
 
     def set_active_pane(self, pane: EditorPane) -> None:
-        self.active_pane = pane
+        self._active_pane = pane
+        if pane.active_editor:
+            self.base.open_editors.set_active(pane.active_editor)
+        self.refresh()
 
     def is_empty(self) -> bool:
         return not self.active_editors
@@ -118,40 +130,44 @@ class EditorsManager(Frame):
             self.add_editor(editor)
 
     def add_editor(self, editor: Union[Editor, BaseEditor]) -> Editor | BaseEditor:
-        """Add a new editor to the editor pane.
-
-        Args:
-            editor (Union[Editor, BaseEditor]): The editor to add."""
-
         if editor in self.active_editors:
             return self.set_active_editor(editor)
 
         self.active_editors.append(editor)
         if editor.content:
-            editor.content.create_buttons(self.editorsbar.action_container)
-        self.editorsbar.add_tab(editor)
+            editor.content.create_buttons(self.active_pane.action_container)
+        self.active_pane.add_tab(editor)
         self.base.open_editors.add_item(editor)
         self.refresh()
         return editor
 
     def delete_all_editors(self) -> None:
-        for tab in self.editorsbar.active_tabs:
-            if e := tab.editor:
-                self.editorsbar.save_unsaved_changes(e)
-                e.destroy()
-
-        self.editorsbar.clear_all_tabs()
-        self.active_editors.clear()
-        for pane in self.panes:
+        editors = list(self.active_editors)
+        for pane in self.get_all_panes():
+            pane.clear_tabs()
             pane.clear()
+        for e in editors:
+            e.destroy()
+        self.active_editors.clear()
         self.base.open_editors.clear()
         self.refresh()
 
+    def save_unsaved_changes(self, e: Editor) -> None:
+        if e.content and e.content.editable and e.content.unsaved_changes:
+            if askyesno(
+                "Unsaved changes",
+                f"Do you want to save the changes you made to {e.filename}",
+            ):
+                if e.exists:
+                    e.save()
+                else:
+                    self.base.commands.save_file_as()
+
     def close_all_editors(self) -> None:
-        for tab in self.editorsbar.active_tabs:
-            if e := tab.editor:
-                self.editorsbar.save_unsaved_changes(e)
-                self.close_editor(e)
+        for pane in list(self.get_all_panes()):
+            for tab in list(pane.active_tabs):
+                self.save_unsaved_changes(tab.editor)
+                pane.close_tab(tab)
         self.refresh()
 
     def reopen_active_editor(self, *_) -> None:
@@ -177,65 +193,40 @@ class EditorsManager(Frame):
             self.base.logger.error(f"Reopening editor failed: {e}")
             self.base.notifications.error("Reopening editor failed: see logs")
 
+    def switch_tabs(self, path: str) -> Editor | None:
+        for pane in self.get_all_panes():
+            for tab in pane.active_tabs:
+                if tab.editor.path == path:
+                    tab.select()
+                    return tab.editor
+
     def open_editor(
         self, path: str = None, exists=True, load_file=True
     ) -> Editor | BaseEditor:
-        """Open a new editor with the given path.
-
-        Args:
-            path (str): The path of the file to open.
-            exists (bool, optional): Whether the file exists. Defaults to True.
-
-        Returns:
-            Editor: The opened editor."""
-
         if path:
             if self.is_open(path):
-                return self.editorsbar.switch_tabs(path)
+                return self.switch_tabs(path)
             if path in self.closed_editors:
                 return self.add_editor(self.closed_editors[path])
 
         return self.add_editor(Editor(self, path, exists, load_file=load_file))
 
     def open_diff_editor(self, path: str, exists: bool) -> None:
-        """Open a new diff editor with the given path.
-
-        Args:
-            path (str): The path of the file to open.
-            exists (bool): Whether the file exists."""
-
         self.add_editor(Editor(self, path, exists, diff=True))
 
     def diff_files(self, file1: str, file2: str, standalone: bool = False) -> None:
-        """Diff two files.
-
-        Args:
-            file1 (str): The path of the first file.
-            file2 (str): The path of the second file."""
-
         self.add_editor(
             Editor(self, file1, True, file2, diff=True, standalone=standalone)
         )
 
     def open_game(self, id: str) -> None:
-        """Open a new game editor with the given id.
-
-        Args:
-            id (str): The id of the game."""
-
         self.add_editor(Game(self, id))
 
     def close_editor(self, editor: Editor) -> None:
-        """Closes the given editor.
-        Keeps the editor in cache.
-
-        Args:
-            editor (Editor): The editor to close."""
-
         if editor in self.active_editors:
             self.active_editors.remove(editor)
 
-        for pane in self.panes:
+        for pane in self.get_all_panes():
             if pane.active_editor == editor:
                 pane.clear()
 
@@ -260,44 +251,32 @@ class EditorsManager(Frame):
             self.base.notifications.info("No recently closed editors to restore")
 
     def close_editor_by_path(self, path: str) -> None:
-        """Closes the editor with the given path.
-        Keeps the editor in cache.
-
-        Args:
-            path (str): The path of the editor to close."""
-
         e = self.get_editor(path)
         self.close_editor(e)
         return e
 
     def get_editor(self, path: str) -> Editor:
-        """Get editor by path.
-
-        Args:
-            path (str): The path of the editor to get."""
-
         for editor in self.active_editors:
             if editor.path == path:
                 return editor
 
     def close_active_editor(self) -> None:
-        self.editorsbar.close_active_tab()
+        if self.active_pane:
+            self.active_pane.close_active_tab()
 
     def delete_editor(self, editor: Editor) -> None:
-        """Delete the given editor.
-
-        Args:
-            editor (Editor): The editor to delete."""
-
         if editor not in self.active_editors:
             return
 
         self.active_editors.remove(editor)
-        self.editorsbar.delete_tab(editor)
 
-        for pane in self.panes:
-            if pane.active_editor == editor:
-                pane.clear()
+        for pane in self.get_all_panes():
+            for tab in list(pane.active_tabs):
+                if tab.editor == editor:
+                    pane.active_tabs.remove(tab)
+                    tab.destroy()
+                    pane.clear()
+                    break
 
         if editor.path in self.closed_editors:
             self.closed_editors.pop(editor.path)
@@ -307,115 +286,189 @@ class EditorsManager(Frame):
         self.refresh()
 
     def set_active_editor(self, editor: Editor) -> Editor:
-        """Set an existing editor to currently shown one.
-
-        Args:
-            editor (Editor): The editor to set as active."""
-
-        for tab in self.editorsbar.active_tabs:
-            if tab.editor == editor:
-                self.editorsbar.set_active_tab(tab)
-        self.base.open_editors.set_active(editor)
-        self.refresh()
+        for pane in self.get_all_panes():
+            for tab in pane.active_tabs:
+                if tab.editor == editor:
+                    tab.select()
+                    self.base.open_editors.set_active(editor)
+                    self.refresh()
+                    return editor
         return editor
 
     def set_active_editor_by_index(self, index: int) -> Editor:
-        """Set an existing editor to currently shown one by index.
-
-        Args:
-            index (int): The index of the editor to set as active."""
-
-        if index < len(self.editorsbar.active_tabs):
-            self.editorsbar.set_active_tab(self.editorsbar.active_tabs[index])
-            return self.editorsbar.active_tabs[index].editor
+        for pane in self.get_all_panes():
+            if index < len(pane.active_tabs):
+                pane.active_tabs[index].select()
+                return pane.active_tabs[index].editor
+            index -= len(pane.active_tabs)
+        return None
 
     def set_active_editor_by_path(self, path: str) -> Editor:
-        """Set an existing editor to currently shown one by path.
-
-        Args:
-            path (str): The path of the editor to set as active."""
-
-        for tab in self.editorsbar.active_tabs:
-            if (
-                tab.editor.path
-                and path
-                and (os.path.abspath(tab.editor.path) == os.path.abspath(path))
-            ):
-                self.editorsbar.set_active_tab(tab)
-                return tab.editor
+        for pane in self.get_all_panes():
+            for tab in pane.active_tabs:
+                if (
+                    tab.editor.path
+                    and path
+                    and (os.path.abspath(tab.editor.path) == os.path.abspath(path))
+                ):
+                    tab.select()
+                    return tab.editor
 
     def close_pane(self, pane: EditorPane) -> None:
-        if len(self.panes) <= 1:
+        parent_pw = self._find_parent_pw(pane)
+        if not parent_pw:
             return
 
-        if pane == self.active_pane:
-            idx = self.panes.index(pane)
-            neighbor = self.panes[idx - 1] if idx > 0 else self.panes[idx + 1]
-            self.active_pane = neighbor
+        if len(self.get_all_panes()) <= 1:
+            return
 
-        self.panes.remove(pane)
-        self.paned_window.forget(pane)
+        if pane == self._active_pane:
+            sibling_paths = [p for p in parent_pw.panes() if p != str(pane)]
+            if sibling_paths:
+                focus = parent_pw.nametowidget(sibling_paths[0])
+                if isinstance(focus, tk.PanedWindow):
+                    focus = self._first_pane(focus)
+                self._active_pane = focus
 
-        if pane.active_editor and pane.active_editor in self.active_editors:
-            pane.active_editor.grid_remove()
+        for tab in list(pane.active_tabs):
+            self.close_editor(tab.editor)
 
+        parent_pw.forget(pane)
         pane.destroy()
+        self._cleanup_empty_pw(parent_pw)
 
-    def _unsplit(self) -> None:
-        if len(self.panes) <= 1:
+    def _cleanup_empty_pw(self, pw: tk.PanedWindow) -> None:
+        if pw.panes():
+            return
+        grandparent = pw.master
+        if isinstance(grandparent, tk.PanedWindow):
+            grandparent.forget(pw)
+            pw.destroy()
+            self._cleanup_empty_pw(grandparent)
+
+    def _find_parent_pw(self, pane: EditorPane) -> tk.PanedWindow | None:
+        for child_path in self.root_pw.panes():
+            child = self.root_pw.nametowidget(child_path)
+            found = self._find_parent_pw_recursive(child, pane)
+            if found:
+                return found
+        return None
+
+    def _find_parent_pw_recursive(
+        self, parent: tk.Widget, pane: EditorPane
+    ) -> tk.PanedWindow | None:
+        if isinstance(parent, tk.PanedWindow):
+            for child_path in parent.panes():
+                child = parent.nametowidget(child_path)
+                if child is pane:
+                    return parent
+                if isinstance(child, tk.PanedWindow):
+                    result = self._find_parent_pw_recursive(child, pane)
+                    if result:
+                        return result
+        return None
+
+    def _first_pane(self, pw: tk.PanedWindow) -> EditorPane | None:
+        for child_path in pw.panes():
+            child = pw.nametowidget(child_path)
+            if isinstance(child, EditorPane):
+                return child
+            if isinstance(child, tk.PanedWindow):
+                return self._first_pane(child)
+        return None
+
+    def _split_pane(self, pane: EditorPane, orient: str) -> None:
+        parent_pw = self._find_parent_pw(pane)
+        if not parent_pw:
             return
 
-        for pane in self.panes[1:]:
-            if pane.active_editor and pane.active_editor in self.active_editors:
-                pane.active_editor.grid_remove()
-            self.paned_window.forget(pane)
-            pane.destroy()
+        idx = list(parent_pw.panes()).index(str(pane))
+        current_path = (
+            pane.active_editor.path
+            if pane.active_editor and pane.active_editor.path
+            else None
+        )
 
-        self.panes = [self.panes[0]]
-        self.active_pane = self.panes[0]
+        parent_pw.forget(pane)
 
-        if not self.panes[0].active_editor:
-            self.panes[0].placeholder.grid()
+        nested = PanedWindow(
+            parent_pw, orient=orient,
+            bg=self.base.theme.border, bd=0,
+            sashwidth=3, sashpad=0, opaqueresize=False,
+        )
 
-    def split_editor(self) -> None:
-        if len(self.panes) > 1:
-            self._unsplit()
-            return
+        sibling = EditorPane(nested, self)
+        if current_path:
+            new_editor = Editor(self, current_path, exists=True)
+            self.active_editors.append(new_editor)
+            sibling.add_tab(new_editor)
+            self.base.open_editors.add_item(new_editor)
 
-        pane = EditorPane(self.paned_window, self)
-        self.paned_window.add(pane, stretch="always")
-        self.paned_window.paneconfigure(pane, minsize=50)
-        self.panes.append(pane)
-        self.active_pane = pane
+        nested.add(pane, stretch="always")
+        nested.add(sibling, stretch="always")
+        nested.paneconfigure(pane, minsize=50)
+        nested.paneconfigure(sibling, minsize=50)
 
+        remaining = list(parent_pw.panes())
+        if idx < len(remaining):
+            parent_pw.add(nested, stretch="always", before=remaining[idx])
+        else:
+            parent_pw.add(nested, stretch="always")
+
+        self._active_pane = sibling
+        self._equalize_pw(parent_pw)
+        self._equalize_pw(nested)
+
+    def split_editor(self, *_) -> None:
+        if self._active_pane:
+            self._split_pane(self._active_pane, tk.HORIZONTAL)
+
+    def split_editor_vertical(self, *_) -> None:
+        if self._active_pane:
+            self._split_pane(self._active_pane, tk.VERTICAL)
+
+    def _equalize_pw(self, pw: tk.PanedWindow) -> None:
         self.update_idletasks()
-        total_width = self.paned_window.winfo_width()
-        if total_width > 0:
-            self.paned_window.sash_place(0, total_width // 2, 0)
+        children = pw.panes()
+        n = len(children)
+        if n <= 1:
+            return
+
+        orient = pw.cget("orient")
+        total = pw.winfo_width() if orient == tk.HORIZONTAL else pw.winfo_height()
+        if total <= 0:
+            return
+
+        for i in range(n - 1):
+            pos = (i + 1) * total // n
+            if orient == tk.HORIZONTAL:
+                pw.sash_place(i, pos, 0)
+            else:
+                pw.sash_place(i, 0, pos)
 
     def change_tab_forward(self) -> None:
-        self.editorsbar.change_tab_forward()
+        if self._active_pane:
+            self._active_pane.change_tab_forward()
 
     def change_tab_back(self) -> None:
-        self.editorsbar.change_tab_back()
+        if self._active_pane:
+            self._active_pane.change_tab_back()
 
     @property
-    def active_editor(self) -> Editor:
-        if not self.active_pane:
-            return
-        return self.active_pane.active_editor
+    def active_editor(self) -> Editor | None:
+        if not self._active_pane:
+            return None
+        return self._active_pane.active_editor
+
+    @property
+    def active_pane(self) -> EditorPane | None:
+        return self._active_pane
 
     def refresh(self) -> None:
         if not self.active_editors:
-            self.editorsbar.clear_buttons()
-            self.editorsbar.active_tabs.clear()
             self.base.set_title(
                 os.path.basename(self.base.active_directory)
                 if self.base.active_directory
                 else None
             )
-            self.editorsbar.hide_tab_container()
-        else:
-            self.editorsbar.show_tab_container()
-
         self.base.update_statusbar()

--- a/src/biscuit/layout/editors/manager.py
+++ b/src/biscuit/layout/editors/manager.py
@@ -347,20 +347,22 @@ class EditorsManager(Frame):
             self._cleanup_empty_pw(grandparent)
 
     def _find_parent_pw(self, pane: EditorPane) -> tk.PanedWindow | None:
-        pane_path = str(pane)
-        for pw in self._iter_panedwindows():
-            if pane_path in pw.panes():
-                return pw
-        return None
+        if str(pane) in self.root_pw.panes():
+            return self.root_pw
+        return self._find_parent_pw_recursive(self.root_pw, pane)
 
-    def _iter_panedwindows(self):
-        pws = [self.root_pw]
-        for pw in pws:
-            yield pw
-            for child_path in pw.panes():
-                child = pw.nametowidget(child_path)
-                if isinstance(child, tk.PanedWindow):
-                    pws.append(child)
+    def _find_parent_pw_recursive(
+        self, pw: tk.PanedWindow, pane: EditorPane
+    ) -> tk.PanedWindow | None:
+        for child_path in pw.panes():
+            child = pw.nametowidget(child_path)
+            if child is pane or str(child) == str(pane):
+                return pw
+            if isinstance(child, tk.PanedWindow):
+                result = self._find_parent_pw_recursive(child, pane)
+                if result:
+                    return result
+        return None
 
     def _first_pane(self, pw: tk.PanedWindow) -> EditorPane | None:
         for child_path in pw.panes():

--- a/src/biscuit/layout/editors/manager.py
+++ b/src/biscuit/layout/editors/manager.py
@@ -47,7 +47,7 @@ class EditorsManager(Frame):
         self._active_pane: EditorPane | None = None
         self._create_initial_pane()
 
-        self.default_editors: List[Editor] = [Welcome(self)]
+        self.default_editors: List[Editor] = [Welcome(self.active_pane)]
 
     def _create_initial_pane(self) -> None:
         pane = EditorPane(self.root_pw, self)
@@ -119,10 +119,10 @@ class EditorsManager(Frame):
         self.add_editors(self.default_editors)
 
     def add_welcome(self) -> None:
-        self.add_editor(Welcome(self))
+        self.add_editor(Welcome(self.active_pane))
 
     def add_search(self) -> None:
-        self.add_editor(SearchEditor(self))
+        self.add_editor(SearchEditor(self.active_pane))
 
     def add_editors(self, editors: list[Editor]) -> None:
         for editor in editors:
@@ -208,18 +208,18 @@ class EditorsManager(Frame):
             if path in self.closed_editors:
                 return self.add_editor(self.closed_editors[path])
 
-        return self.add_editor(Editor(self, path, exists, load_file=load_file))
+        return self.add_editor(Editor(self.active_pane, path, exists, load_file=load_file))
 
     def open_diff_editor(self, path: str, exists: bool) -> None:
-        self.add_editor(Editor(self, path, exists, diff=True))
+        self.add_editor(Editor(self.active_pane, path, exists, diff=True))
 
     def diff_files(self, file1: str, file2: str, standalone: bool = False) -> None:
         self.add_editor(
-            Editor(self, file1, True, file2, diff=True, standalone=standalone)
+            Editor(self.active_pane, file1, True, file2, diff=True, standalone=standalone)
         )
 
     def open_game(self, id: str) -> None:
-        self.add_editor(Game(self, id))
+        self.add_editor(Game(self.active_pane, id))
 
     def close_editor(self, editor: Editor) -> None:
         if editor in self.active_editors:
@@ -229,7 +229,10 @@ class EditorsManager(Frame):
             if pane.active_editor == editor:
                 pane.clear()
 
-        editor.grid_forget()
+        try:
+            editor.grid_forget()
+        except tk.TclError:
+            pass
         self.refresh()
 
         if editor.content and editor.content.editable:
@@ -407,7 +410,7 @@ class EditorsManager(Frame):
 
         sibling = EditorPane(nested, self)
         if current_path:
-            new_editor = Editor(self, current_path, exists=True)
+            new_editor = Editor(sibling, current_path, exists=True)
             self.active_editors.append(new_editor)
             sibling.add_tab(new_editor)
             self.base.open_editors.add_item(new_editor)

--- a/src/biscuit/layout/editors/manager.py
+++ b/src/biscuit/layout/editors/manager.py
@@ -349,9 +349,12 @@ class EditorsManager(Frame):
     def _find_parent_pw(self, pane: EditorPane) -> tk.PanedWindow | None:
         for child_path in self.root_pw.panes():
             child = self.root_pw.nametowidget(child_path)
-            found = self._find_parent_pw_recursive(child, pane)
-            if found:
-                return found
+            if child is pane:
+                return self.root_pw
+            if isinstance(child, tk.PanedWindow):
+                found = self._find_parent_pw_recursive(child, pane)
+                if found:
+                    return found
         return None
 
     def _find_parent_pw_recursive(

--- a/src/biscuit/layout/editors/manager.py
+++ b/src/biscuit/layout/editors/manager.py
@@ -58,6 +58,19 @@ class EditorsManager(Frame):
     def _pw_child(self, pw, path):
         return pw.nametowidget(str(path))
 
+    def _collect_widget_paths(self, widget):
+        paths = {}
+        stack = [widget]
+        while stack:
+            w = stack.pop()
+            paths[w] = w._w
+            try:
+                for c in w.winfo_children():
+                    stack.append(c)
+            except tk.TclError:
+                continue
+        return paths
+
     def get_all_panes(self) -> list[EditorPane]:
         result: list[EditorPane] = []
         self._collect_panes(self.root_pw, result)
@@ -423,10 +436,19 @@ class EditorsManager(Frame):
             sibling.add_tab(new_editor)
             self.base.open_editors.add_item(new_editor)
 
+        # pane's _w and all children's _w become stale after nested.add() reparents.
+        # Save old paths before reparenting so we can reconstruct them.
+        old_pane_w = pane._w
+        old_paths = self._collect_widget_paths(pane)
+
         nested.add(pane, stretch="always")
         nested.add(sibling, stretch="always")
         nested.paneconfigure(pane, minsize=50)
         nested.paneconfigure(sibling, minsize=50)
+
+        pane._w = nested._w + '.' + old_pane_w.rsplit('.', 1)[1]
+        for widget, old_w in old_paths.items():
+            widget._w = old_w.replace(old_pane_w, pane._w, 1)
 
         remaining = list(parent_pw.panes())
         if idx < len(remaining):
@@ -438,7 +460,7 @@ class EditorsManager(Frame):
         self._equalize_pw(parent_pw)
         self._equalize_pw(nested)
 
-        # restore pane A's grid children after forget+add collapses geometry
+        # restore grid children after pane's geometry was collapsed by forget+add
         pane._update_tab_bar_visibility()
         if pane.active_editor and pane.active_editor.path and pane.active_editor.showpath:
             pane.show_breadcrumbs()

--- a/src/biscuit/layout/editors/manager.py
+++ b/src/biscuit/layout/editors/manager.py
@@ -47,7 +47,7 @@ class EditorsManager(Frame):
         self._active_pane: EditorPane | None = None
         self._create_initial_pane()
 
-        self.default_editors: List[Editor] = [Welcome(self.active_pane)]
+        self.default_editors: List[Editor] = [Welcome(self)]
 
     def _create_initial_pane(self) -> None:
         pane = EditorPane(self.root_pw, self)
@@ -119,10 +119,10 @@ class EditorsManager(Frame):
         self.add_editors(self.default_editors)
 
     def add_welcome(self) -> None:
-        self.add_editor(Welcome(self.active_pane))
+        self.add_editor(Welcome(self))
 
     def add_search(self) -> None:
-        self.add_editor(SearchEditor(self.active_pane))
+        self.add_editor(SearchEditor(self))
 
     def add_editors(self, editors: list[Editor]) -> None:
         for editor in editors:
@@ -208,18 +208,18 @@ class EditorsManager(Frame):
             if path in self.closed_editors:
                 return self.add_editor(self.closed_editors[path])
 
-        return self.add_editor(Editor(self.active_pane, path, exists, load_file=load_file))
+        return self.add_editor(Editor(self, path, exists, load_file=load_file))
 
     def open_diff_editor(self, path: str, exists: bool) -> None:
-        self.add_editor(Editor(self.active_pane, path, exists, diff=True))
+        self.add_editor(Editor(self, path, exists, diff=True))
 
     def diff_files(self, file1: str, file2: str, standalone: bool = False) -> None:
         self.add_editor(
-            Editor(self.active_pane, file1, True, file2, diff=True, standalone=standalone)
+            Editor(self, file1, True, file2, diff=True, standalone=standalone)
         )
 
     def open_game(self, id: str) -> None:
-        self.add_editor(Game(self.active_pane, id))
+        self.add_editor(Game(self, id))
 
     def close_editor(self, editor: Editor) -> None:
         if editor in self.active_editors:
@@ -410,7 +410,7 @@ class EditorsManager(Frame):
 
         sibling = EditorPane(nested, self)
         if current_path:
-            new_editor = Editor(sibling, current_path, exists=True)
+            new_editor = Editor(self, current_path, exists=True)
             self.active_editors.append(new_editor)
             sibling.add_tab(new_editor)
             self.base.open_editors.add_item(new_editor)

--- a/src/biscuit/layout/editors/manager.py
+++ b/src/biscuit/layout/editors/manager.py
@@ -428,22 +428,21 @@ class EditorsManager(Frame):
         if not needs_nesting:
             parent_pw.configure(orient=orient)
             sibling = EditorPane(parent_pw, self)
+            sibling_editor = None
             if current_path:
-                new_editor = Editor(self, current_path, exists=current_exists, showpath=current_showpath)
-                self.active_editors.append(new_editor)
-                sibling.add_tab(new_editor)
-                self.base.open_editors.add_item(new_editor)
+                sibling_editor = Editor(self, current_path, exists=current_exists, showpath=current_showpath)
+            elif active and active.new_like(self):
+                sibling_editor = active.new_like(self)
+            if sibling_editor:
+                self.active_editors.append(sibling_editor)
+                sibling.add_tab(sibling_editor)
+                self.base.open_editors.add_item(sibling_editor)
             parent_pw.add(pane, stretch="always")
             parent_pw.add(sibling, stretch="always")
             parent_pw.paneconfigure(pane, minsize=50)
             parent_pw.paneconfigure(sibling, minsize=50)
             self._active_pane = sibling
         else:
-            saved_editors = [tab.editor for tab in list(pane.active_tabs)]
-
-            pane.clear_tabs()
-            pane.destroy()
-
             nested = PanedWindow(
                 parent_pw, orient=orient,
                 bg=self.base.theme.border, bd=0,
@@ -455,23 +454,42 @@ class EditorsManager(Frame):
             else:
                 parent_pw.add(nested, stretch="always")
 
-            new_pane = EditorPane(nested, self)
+            same_type = all(isinstance(tab.editor, Editor) for tab in pane.active_tabs)
+            if same_type and pane.active_tabs:
+                saved_editors = [tab.editor for tab in list(pane.active_tabs)]
+                pane.clear_tabs()
+                pane.destroy()
+
+                new_pane = EditorPane(nested, self)
+
+                for editor in saved_editors:
+                    new_pane.add_tab(editor)
+
+                nested.add(new_pane, stretch="always")
+            else:
+                nested.add(pane, stretch="always")
+                pane._update_tab_bar_visibility()
+                if pane.active_editor:
+                    pane.set_active_editor(pane.active_editor)
+                nested.paneconfigure(pane, minsize=50)
+
             sibling = EditorPane(nested, self)
-
-            for editor in saved_editors:
-                new_pane.add_tab(editor)
-
-            if current_path:
-                new_editor = Editor(self, current_path, exists=current_exists, showpath=current_showpath)
-                self.active_editors.append(new_editor)
-                sibling.add_tab(new_editor)
-                self.base.open_editors.add_item(new_editor)
-
-            nested.add(new_pane, stretch="always")
             nested.add(sibling, stretch="always")
-            nested.paneconfigure(new_pane, minsize=50)
+
+            sibling_editor = None
+            if current_path:
+                sibling_editor = Editor(self, current_path, exists=current_exists, showpath=current_showpath)
+            elif active and active.new_like(self):
+                sibling_editor = active.new_like(self)
+
+            if sibling_editor:
+                self.active_editors.append(sibling_editor)
+                sibling.add_tab(sibling_editor)
+                self.base.open_editors.add_item(sibling_editor)
+
             nested.paneconfigure(sibling, minsize=50)
             self._active_pane = sibling
+            self._equalize_pw(nested)
 
         self._equalize_pw(parent_pw)
 

--- a/src/biscuit/layout/editors/manager.py
+++ b/src/biscuit/layout/editors/manager.py
@@ -374,11 +374,25 @@ class EditorsManager(Frame):
         return None
 
     def _split_pane(self, pane: EditorPane, orient: str) -> None:
+        pane_path = str(pane)
+        root_panes = self.root_pw.panes()
+        print(f"DEBUG split: pane_path={pane_path!r} root_panes={root_panes!r}")
+        print(f"DEBUG split: type={type(root_panes)} len={len(root_panes)}")
+        if root_panes:
+            print(f"DEBUG split: first_child={root_panes[0]!r} match={root_panes[0] == pane_path}")
+        print(f"DEBUG split: in? {pane_path in root_panes}")
+        for i, cp in enumerate(root_panes):
+            print(f"DEBUG split:  child[{i}]={cp!r}")
+            print(f"DEBUG split:  child[{i}]==path? {cp == pane_path}")
+
         parent_pw = self._find_parent_pw(pane)
         if not parent_pw:
+            print(f"DEBUG split: NO PARENT FOUND!")
             return
 
-        idx = list(parent_pw.panes()).index(str(pane))
+        print(f"DEBUG split: parent_pw={parent_pw} pw.panes()={parent_pw.panes()!r}")
+
+        idx = list(parent_pw.panes()).index(pane_path)
         current_path = (
             pane.active_editor.path
             if pane.active_editor and pane.active_editor.path

--- a/src/biscuit/layout/editors/manager.py
+++ b/src/biscuit/layout/editors/manager.py
@@ -428,7 +428,8 @@ class EditorsManager(Frame):
         nested.paneconfigure(pane, minsize=50)
         nested.paneconfigure(sibling, minsize=50)
 
-        # refresh breadcrumbs on moved pane (forget+add can lose grid state)
+        # restore pane A's grid state after forget+add (geometry collapse)
+        pane._update_tab_bar_visibility()
         if pane.active_editor and pane.active_editor.path and pane.active_editor.showpath:
             pane.show_breadcrumbs()
             pane.breadcrumbs.set_path(pane.active_editor.path)

--- a/src/biscuit/layout/editors/manager.py
+++ b/src/biscuit/layout/editors/manager.py
@@ -422,51 +422,59 @@ class EditorsManager(Frame):
         )
 
         parent_pw.forget(pane)
-
-        nested = PanedWindow(
-            parent_pw, orient=orient,
-            bg=self.base.theme.border, bd=0,
-            sashwidth=3, sashpad=0, opaqueresize=False,
-        )
-
-        sibling = EditorPane(nested, self)
-        if current_path:
-            new_editor = Editor(self, current_path, exists=True)
-            self.active_editors.append(new_editor)
-            sibling.add_tab(new_editor)
-            self.base.open_editors.add_item(new_editor)
-
-        # pane's _w and all children's _w become stale after nested.add() reparents.
-        # Save old paths before reparenting so we can reconstruct them.
-        old_pane_w = pane._w
-        old_paths = self._collect_widget_paths(pane)
-
-        nested.add(pane, stretch="always")
-        nested.add(sibling, stretch="always")
-        nested.paneconfigure(pane, minsize=50)
-        nested.paneconfigure(sibling, minsize=50)
-
-        pane._w = nested._w + '.' + old_pane_w.rsplit('.', 1)[1]
-        for widget, old_w in old_paths.items():
-            widget._w = old_w.replace(old_pane_w, pane._w, 1)
-
         remaining = list(parent_pw.panes())
-        if idx < len(remaining):
-            parent_pw.add(nested, stretch="always", before=remaining[idx])
-        else:
-            parent_pw.add(nested, stretch="always")
 
-        self._active_pane = sibling
+        needs_nesting = bool(remaining) or parent_pw is not self.root_pw
+
+        if not needs_nesting:
+            parent_pw.configure(orient=orient)
+            sibling = EditorPane(parent_pw, self)
+            if current_path:
+                new_editor = Editor(self, current_path, exists=True)
+                self.active_editors.append(new_editor)
+                sibling.add_tab(new_editor)
+                self.base.open_editors.add_item(new_editor)
+            parent_pw.add(pane, stretch="always")
+            parent_pw.add(sibling, stretch="always")
+            parent_pw.paneconfigure(pane, minsize=50)
+            parent_pw.paneconfigure(sibling, minsize=50)
+            self._active_pane = sibling
+        else:
+            saved_editors = [tab.editor for tab in list(pane.active_tabs)]
+
+            pane.clear_tabs()
+            pane.destroy()
+
+            nested = PanedWindow(
+                parent_pw, orient=orient,
+                bg=self.base.theme.border, bd=0,
+                sashwidth=3, sashpad=0, opaqueresize=False,
+            )
+
+            if idx < len(remaining):
+                parent_pw.add(nested, stretch="always", before=remaining[idx])
+            else:
+                parent_pw.add(nested, stretch="always")
+
+            new_pane = EditorPane(nested, self)
+            sibling = EditorPane(nested, self)
+
+            for editor in saved_editors:
+                new_pane.add_tab(editor)
+
+            if current_path:
+                new_editor = Editor(self, current_path, exists=True)
+                self.active_editors.append(new_editor)
+                sibling.add_tab(new_editor)
+                self.base.open_editors.add_item(new_editor)
+
+            nested.add(new_pane, stretch="always")
+            nested.add(sibling, stretch="always")
+            nested.paneconfigure(new_pane, minsize=50)
+            nested.paneconfigure(sibling, minsize=50)
+            self._active_pane = sibling
+
         self._equalize_pw(parent_pw)
-        self._equalize_pw(nested)
-
-        # restore grid children after pane's geometry was collapsed by forget+add
-        pane._update_tab_bar_visibility()
-        if pane.active_editor and pane.active_editor.path and pane.active_editor.showpath:
-            pane.show_breadcrumbs()
-            pane.breadcrumbs.set_path(pane.active_editor.path)
-        else:
-            pane.hide_breadcrumbs()
 
     def split_editor(self, *_) -> None:
         if self._active_pane:

--- a/src/biscuit/layout/editors/manager.py
+++ b/src/biscuit/layout/editors/manager.py
@@ -4,14 +4,14 @@ import os
 import tkinter as tk
 import typing
 from tkinter.messagebox import askyesno
-from typing import Dict, List, Union
+from typing import List, Union
 
 from biscuit.common import ActionSet, Game
-from biscuit.common.ui import Frame
+from biscuit.common.ui import Frame, PanedWindow
 from biscuit.editor import Editor, SearchEditor, Welcome
 
 from .editorsbar import EditorsBar
-from .placeholder import Placeholder
+from .pane import EditorPane
 
 if typing.TYPE_CHECKING:
     from biscuit.editor import BaseEditor
@@ -20,11 +20,11 @@ if typing.TYPE_CHECKING:
 
 
 class EditorsManager(Frame):
-    """Editors Pane
+    """Editors Manager
 
     - Contains the Editorsbar
-    - Manages the Editorsbar
-    - Manages the Editors
+    - Manages split panes (EditorPane instances) via a PanedWindow
+    - Each pane shows one editor at a time
     """
 
     def __init__(self, master: Content, *args, **kwargs) -> None:
@@ -39,15 +39,32 @@ class EditorsManager(Frame):
         self.editorsbar.grid(row=0, column=0, sticky=tk.EW, pady=(0, 1))
 
         self.active_editors: List[Editor] = []
-        self.closed_editors: Dict[Editor] = {}
-
         self.closed_editors: List[Editor] = []
         self.max_closed_editors = 10
 
-        self.emptytab = Placeholder(self)
-        self.emptytab.grid(column=0, row=1, sticky=tk.NSEW)
+        self.paned_window = PanedWindow(
+            self, orient=tk.HORIZONTAL,
+            bg=self.base.theme.border, bd=0,
+            sashwidth=3, sashpad=0, opaqueresize=False,
+        )
+        self.paned_window.grid(row=1, column=0, sticky=tk.NSEW)
+
+        self.panes: List[EditorPane] = []
+        self.active_pane: EditorPane | None = None
+
+        self._create_initial_pane()
 
         self.default_editors: List[Editor] = [Welcome(self)]
+
+    def _create_initial_pane(self) -> None:
+        pane = EditorPane(self.paned_window, self)
+        self.paned_window.add(pane, stretch="always")
+        self.paned_window.paneconfigure(pane, minsize=50)
+        self.panes.append(pane)
+        self.active_pane = pane
+
+    def set_active_pane(self, pane: EditorPane) -> None:
+        self.active_pane = pane
 
     def is_empty(self) -> bool:
         return not self.active_editors
@@ -125,6 +142,8 @@ class EditorsManager(Frame):
 
         self.editorsbar.clear_all_tabs()
         self.active_editors.clear()
+        for pane in self.panes:
+            pane.clear()
         self.base.open_editors.clear()
         self.refresh()
 
@@ -136,10 +155,12 @@ class EditorsManager(Frame):
         self.refresh()
 
     def reopen_active_editor(self, *_) -> None:
-        if self.active_editor and self.active_editor.exists:
-            self.delete_editor(self.active_editor)
-            self.update()
-            self.open_editor(self.active_editor.path)
+        if editor := self.active_editor:
+            if editor.exists:
+                path = editor.path
+                self.delete_editor(editor)
+                self.update()
+                self.open_editor(path)
 
     def reopen_editor(self, path: str):
         if not askyesno(
@@ -213,6 +234,11 @@ class EditorsManager(Frame):
 
         if editor in self.active_editors:
             self.active_editors.remove(editor)
+
+        for pane in self.panes:
+            if pane.active_editor == editor:
+                pane.clear()
+
         editor.grid_forget()
         self.refresh()
 
@@ -230,7 +256,6 @@ class EditorsManager(Frame):
         if self.closed_editors:
             editor = self.closed_editors.pop()
             self.add_editor(editor)
-            # self.base.notifications.info(f"Restored {editor.filename}")
         else:
             self.base.notifications.info("No recently closed editors to restore")
 
@@ -269,6 +294,11 @@ class EditorsManager(Frame):
 
         self.active_editors.remove(editor)
         self.editorsbar.delete_tab(editor)
+
+        for pane in self.panes:
+            if pane.active_editor == editor:
+                pane.clear()
+
         if editor.path in self.closed_editors:
             self.closed_editors.pop(editor.path)
 
@@ -314,9 +344,54 @@ class EditorsManager(Frame):
                 self.editorsbar.set_active_tab(tab)
                 return tab.editor
 
+    def close_pane(self, pane: EditorPane) -> None:
+        if len(self.panes) <= 1:
+            return
+
+        if pane == self.active_pane:
+            idx = self.panes.index(pane)
+            neighbor = self.panes[idx - 1] if idx > 0 else self.panes[idx + 1]
+            self.active_pane = neighbor
+
+        self.panes.remove(pane)
+        self.paned_window.forget(pane)
+
+        if pane.active_editor and pane.active_editor in self.active_editors:
+            pane.active_editor.grid_remove()
+
+        pane.destroy()
+
+    def _unsplit(self) -> None:
+        if len(self.panes) <= 1:
+            return
+
+        for pane in self.panes[1:]:
+            if pane.active_editor and pane.active_editor in self.active_editors:
+                pane.active_editor.grid_remove()
+            self.paned_window.forget(pane)
+            pane.destroy()
+
+        self.panes = [self.panes[0]]
+        self.active_pane = self.panes[0]
+
+        if not self.panes[0].active_editor:
+            self.panes[0].placeholder.grid()
+
     def split_editor(self) -> None:
-        # TODO: Implement split editor
-        ...
+        if len(self.panes) > 1:
+            self._unsplit()
+            return
+
+        pane = EditorPane(self.paned_window, self)
+        self.paned_window.add(pane, stretch="always")
+        self.paned_window.paneconfigure(pane, minsize=50)
+        self.panes.append(pane)
+        self.active_pane = pane
+
+        self.update_idletasks()
+        total_width = self.paned_window.winfo_width()
+        if total_width > 0:
+            self.paned_window.sash_place(0, total_width // 2, 0)
 
     def change_tab_forward(self) -> None:
         self.editorsbar.change_tab_forward()
@@ -326,15 +401,13 @@ class EditorsManager(Frame):
 
     @property
     def active_editor(self) -> Editor:
-        if not self.editorsbar.active_tab:
+        if not self.active_pane:
             return
-
-        return self.editorsbar.active_tab.editor
+        return self.active_pane.active_editor
 
     def refresh(self) -> None:
         if not self.active_editors:
             self.editorsbar.clear_buttons()
-            self.emptytab.grid()
             self.editorsbar.active_tabs.clear()
             self.base.set_title(
                 os.path.basename(self.base.active_directory)
@@ -344,6 +417,5 @@ class EditorsManager(Frame):
             self.editorsbar.hide_tab_container()
         else:
             self.editorsbar.show_tab_container()
-            self.emptytab.grid_remove()
 
         self.base.update_statusbar()

--- a/src/biscuit/layout/editors/manager.py
+++ b/src/biscuit/layout/editors/manager.py
@@ -428,6 +428,13 @@ class EditorsManager(Frame):
         nested.paneconfigure(pane, minsize=50)
         nested.paneconfigure(sibling, minsize=50)
 
+        # refresh breadcrumbs on moved pane (forget+add can lose grid state)
+        if pane.active_editor and pane.active_editor.path and pane.active_editor.showpath:
+            pane.show_breadcrumbs()
+            pane.breadcrumbs.set_path(pane.active_editor.path)
+        else:
+            pane.hide_breadcrumbs()
+
         remaining = list(parent_pw.panes())
         if idx < len(remaining):
             parent_pw.add(nested, stretch="always", before=remaining[idx])

--- a/src/biscuit/layout/editors/manager.py
+++ b/src/biscuit/layout/editors/manager.py
@@ -428,14 +428,6 @@ class EditorsManager(Frame):
         nested.paneconfigure(pane, minsize=50)
         nested.paneconfigure(sibling, minsize=50)
 
-        # restore pane A's grid state after forget+add (geometry collapse)
-        pane._update_tab_bar_visibility()
-        if pane.active_editor and pane.active_editor.path and pane.active_editor.showpath:
-            pane.show_breadcrumbs()
-            pane.breadcrumbs.set_path(pane.active_editor.path)
-        else:
-            pane.hide_breadcrumbs()
-
         remaining = list(parent_pw.panes())
         if idx < len(remaining):
             parent_pw.add(nested, stretch="always", before=remaining[idx])
@@ -445,6 +437,14 @@ class EditorsManager(Frame):
         self._active_pane = sibling
         self._equalize_pw(parent_pw)
         self._equalize_pw(nested)
+
+        # restore pane A's grid children after forget+add collapses geometry
+        pane._update_tab_bar_visibility()
+        if pane.active_editor and pane.active_editor.path and pane.active_editor.showpath:
+            pane.show_breadcrumbs()
+            pane.breadcrumbs.set_path(pane.active_editor.path)
+        else:
+            pane.hide_breadcrumbs()
 
     def split_editor(self, *_) -> None:
         if self._active_pane:

--- a/src/biscuit/layout/editors/manager.py
+++ b/src/biscuit/layout/editors/manager.py
@@ -415,11 +415,10 @@ class EditorsManager(Frame):
                 break
         if idx is None:
             return
-        current_path = (
-            pane.active_editor.path
-            if pane.active_editor and pane.active_editor.path
-            else None
-        )
+        active = pane.active_editor
+        current_path = active.path if active and active.path else None
+        current_exists = active.exists if active else True
+        current_showpath = active.showpath if active else True
 
         parent_pw.forget(pane)
         remaining = list(parent_pw.panes())
@@ -430,7 +429,7 @@ class EditorsManager(Frame):
             parent_pw.configure(orient=orient)
             sibling = EditorPane(parent_pw, self)
             if current_path:
-                new_editor = Editor(self, current_path, exists=True)
+                new_editor = Editor(self, current_path, exists=current_exists, showpath=current_showpath)
                 self.active_editors.append(new_editor)
                 sibling.add_tab(new_editor)
                 self.base.open_editors.add_item(new_editor)
@@ -463,7 +462,7 @@ class EditorsManager(Frame):
                 new_pane.add_tab(editor)
 
             if current_path:
-                new_editor = Editor(self, current_path, exists=True)
+                new_editor = Editor(self, current_path, exists=current_exists, showpath=current_showpath)
                 self.active_editors.append(new_editor)
                 sibling.add_tab(new_editor)
                 self.base.open_editors.add_item(new_editor)

--- a/src/biscuit/layout/editors/manager.py
+++ b/src/biscuit/layout/editors/manager.py
@@ -55,13 +55,17 @@ class EditorsManager(Frame):
         self.root_pw.paneconfigure(pane, minsize=50)
         self._active_pane = pane
 
+    def _pw_child(self, pw, path):
+        return pw.nametowidget(str(path))
+
     def get_all_panes(self) -> list[EditorPane]:
         result: list[EditorPane] = []
         self._collect_panes(self.root_pw, result)
         return result
 
     def _collect_panes(self, parent: tk.PanedWindow, result: list[EditorPane]) -> None:
-        for child in parent.panes():
+        for child_path in parent.panes():
+            child = self._pw_child(parent, child_path)
             if isinstance(child, EditorPane):
                 result.append(child)
             elif isinstance(child, tk.PanedWindow):
@@ -326,7 +330,8 @@ class EditorsManager(Frame):
 
         if pane is self._active_pane:
             sibling = None
-            for child in parent_pw.panes():
+            for child_path in parent_pw.panes():
+                child = self._pw_child(parent_pw, child_path)
                 if child is not pane:
                     sibling = child
                     break
@@ -353,7 +358,8 @@ class EditorsManager(Frame):
             self._cleanup_empty_pw(grandparent)
 
     def _find_parent_pw(self, pane: EditorPane) -> tk.PanedWindow | None:
-        for child in self.root_pw.panes():
+        for child_path in self.root_pw.panes():
+            child = self._pw_child(self.root_pw, child_path)
             if child is pane:
                 return self.root_pw
             if isinstance(child, tk.PanedWindow):
@@ -365,7 +371,8 @@ class EditorsManager(Frame):
     def _find_parent_pw_recursive(
         self, pw: tk.PanedWindow, pane: EditorPane
     ) -> tk.PanedWindow | None:
-        for child in pw.panes():
+        for child_path in pw.panes():
+            child = self._pw_child(pw, child_path)
             if child is pane:
                 return pw
             if isinstance(child, tk.PanedWindow):
@@ -375,7 +382,8 @@ class EditorsManager(Frame):
         return None
 
     def _first_pane(self, pw: tk.PanedWindow) -> EditorPane | None:
-        for child in pw.panes():
+        for child_path in pw.panes():
+            child = self._pw_child(pw, child_path)
             if isinstance(child, EditorPane):
                 return child
             if isinstance(child, tk.PanedWindow):
@@ -388,8 +396,8 @@ class EditorsManager(Frame):
             return
 
         idx = None
-        for i, child in enumerate(parent_pw.panes()):
-            if child is pane:
+        for i, child_path in enumerate(parent_pw.panes()):
+            if self._pw_child(parent_pw, child_path) is pane:
                 idx = i
                 break
         if idx is None:

--- a/src/biscuit/layout/editors/pane.py
+++ b/src/biscuit/layout/editors/pane.py
@@ -34,17 +34,12 @@ class EditorPane(Frame):
         self.breadcrumbs.pack(fill=tk.X, side=tk.TOP)
         self.breadcrumbs_container.grid_remove()
 
-        self.editor_container = Frame(self)
-        self.editor_container.grid(row=2, column=0, sticky=tk.NSEW)
-        self.editor_container.grid_rowconfigure(0, weight=1)
-        self.editor_container.grid_columnconfigure(0, weight=1)
-
         self.active_tabs: list[Tab] = []
         self.active_tab: Tab | None = None
         self.active_editor: Editor | None = None
 
-        self.placeholder = Placeholder(self.editor_container)
-        self.placeholder.grid(row=0, column=0, sticky=tk.NSEW)
+        self.placeholder = Placeholder(self)
+        self.placeholder.grid(row=2, column=0, sticky=tk.NSEW)
 
         self.bind("<Button-1>", self.focus_pane)
         self.placeholder.bind("<Button-1>", self.focus_pane)
@@ -136,15 +131,17 @@ class EditorPane(Frame):
 
     def set_active_editor(self, editor: Editor | None) -> None:
         if self.active_editor and self.active_editor != editor:
-            self.active_editor.grid_remove()
+            try:
+                self.active_editor.grid_remove()
+            except tk.TclError:
+                pass
 
         if editor:
-            editor.grid(row=0, column=0, sticky=tk.NSEW, in_=self.editor_container)
+            editor.grid(row=2, column=0, sticky=tk.NSEW)
             editor.tkraise()
             self.placeholder.grid_remove()
         else:
             self.placeholder.grid()
-
         self.active_editor = editor
 
     def add_tab(self, editor: Editor) -> Tab:

--- a/src/biscuit/layout/editors/pane.py
+++ b/src/biscuit/layout/editors/pane.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import tkinter as tk
+import typing
+
+from biscuit.common.ui import Frame
+from biscuit.layout.editors.placeholder import Placeholder
+
+if typing.TYPE_CHECKING:
+    from biscuit.editor import Editor
+    from .manager import EditorsManager
+
+
+class EditorPane(Frame):
+    def __init__(self, master, editors_manager: EditorsManager, *args, **kwargs) -> None:
+        super().__init__(master, *args, **kwargs)
+        self.editors_manager = editors_manager
+        self.config(bg=self.base.theme.border)
+
+        self.grid_rowconfigure(0, weight=1)
+        self.grid_columnconfigure(0, weight=1)
+
+        self.active_editor: Editor | None = None
+        self.placeholder = Placeholder(self)
+        self.placeholder.grid(row=0, column=0, sticky=tk.NSEW)
+
+        self.bind("<Button-1>", self.focus_pane)
+        self.placeholder.bind("<Button-1>", self.focus_pane)
+
+    def focus_pane(self, *_) -> None:
+        self.editors_manager.set_active_pane(self)
+
+    def set_active_editor(self, editor: Editor | None) -> None:
+        if self.active_editor and self.active_editor != editor:
+            self.active_editor.grid_remove()
+
+        if editor:
+            editor.grid(row=0, column=0, sticky=tk.NSEW, in_=self)
+            editor.tkraise()
+            self.placeholder.grid_remove()
+        else:
+            self.placeholder.grid()
+
+        self.active_editor = editor
+
+    def clear(self) -> None:
+        if self.active_editor:
+            self.active_editor.grid_remove()
+            self.active_editor = None
+        self.placeholder.grid()

--- a/src/biscuit/layout/editors/pane.py
+++ b/src/biscuit/layout/editors/pane.py
@@ -71,14 +71,14 @@ class EditorPane(Frame):
             self.base.commands.restore_last_closed_editor,
         )
         self.menu.add_separator(10)
-        self.menu.add_command("Split Editor", self.base.commands.split_editor)
+        self.menu.add_command("Split Editor", self.split_pane)
         self.menu.add_command(
-            "Split Editor Vertical", self.base.commands.split_editor_vertical
+            "Split Editor Vertical", self.split_pane_vertical
         )
         self.menu.add_separator(10)
         self.menu.add_command(
             "Close Split",
-            lambda p=self: self.editors_manager.close_pane(p),
+            lambda: self.editors_manager.close_pane(self),
         )
         self.menu.add_command("Close All", self.editors_manager.delete_all_editors)
 
@@ -86,7 +86,7 @@ class EditorPane(Frame):
         default_buttons = (
             (Icons.ELLIPSIS, self.menu.show),
             (Icons.CHEVRON_DOWN, self.base.open_editors.show),
-            (Icons.ADD, self.base.commands.open_empty_editor),
+            (Icons.ADD, self.add_empty_editor),
         )
 
         for button in default_buttons:
@@ -105,7 +105,7 @@ class EditorPane(Frame):
             iconsize=12,
             pady=6,
             hfg_only=True,
-            event=self.editors_manager.split_editor,
+            event=self.split_pane,
         ).pack(side=tk.RIGHT, fill=tk.Y)
 
     def _update_tab_bar_visibility(self) -> None:
@@ -124,6 +124,18 @@ class EditorPane(Frame):
 
     def focus_pane(self, *_) -> None:
         self.editors_manager.set_active_pane(self)
+
+    def add_empty_editor(self, *_) -> None:
+        self.focus_pane()
+        self.base.commands.new_file()
+
+    def split_pane(self, *_) -> None:
+        self.focus_pane()
+        self.editors_manager._split_pane(self, tk.HORIZONTAL)
+
+    def split_pane_vertical(self, *_) -> None:
+        self.focus_pane()
+        self.editors_manager._split_pane(self, tk.VERTICAL)
 
     def is_empty(self) -> bool:
         return not self.active_tabs

--- a/src/biscuit/layout/editors/pane.py
+++ b/src/biscuit/layout/editors/pane.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
+import os
 import tkinter as tk
 import typing
+from tkinter.messagebox import askyesno
 
-from biscuit.common.ui import Frame
+from biscuit.common.icons import Icons
+from biscuit.common.ui import Frame, IconButton
+from biscuit.editor import BreadCrumbs, Editor
+from biscuit.layout.editors.menu import EditorsbarMenu
 from biscuit.layout.editors.placeholder import Placeholder
+from biscuit.layout.editors.tab import Tab
 
 if typing.TYPE_CHECKING:
-    from biscuit.editor import Editor
     from .manager import EditorsManager
 
 
@@ -17,25 +22,124 @@ class EditorPane(Frame):
         self.editors_manager = editors_manager
         self.config(bg=self.base.theme.border)
 
-        self.grid_rowconfigure(0, weight=1)
+        self.grid_rowconfigure(2, weight=1)
         self.grid_columnconfigure(0, weight=1)
 
+        self._build_tab_bar()
+
+        self.breadcrumbs_container = Frame(self)
+        self.breadcrumbs_container.grid(row=1, column=0, sticky=tk.EW)
+
+        self.breadcrumbs = BreadCrumbs(self.breadcrumbs_container)
+        self.breadcrumbs.pack(fill=tk.X, side=tk.TOP)
+        self.breadcrumbs_container.grid_remove()
+
+        self.editor_container = Frame(self)
+        self.editor_container.grid(row=2, column=0, sticky=tk.NSEW)
+        self.editor_container.grid_rowconfigure(0, weight=1)
+        self.editor_container.grid_columnconfigure(0, weight=1)
+
+        self.active_tabs: list[Tab] = []
+        self.active_tab: Tab | None = None
         self.active_editor: Editor | None = None
-        self.placeholder = Placeholder(self)
+
+        self.placeholder = Placeholder(self.editor_container)
         self.placeholder.grid(row=0, column=0, sticky=tk.NSEW)
 
         self.bind("<Button-1>", self.focus_pane)
         self.placeholder.bind("<Button-1>", self.focus_pane)
+        self.tab_bar.grid_remove()
+
+    def _build_tab_bar(self) -> None:
+        self.tab_bar = Frame(self, **self.base.theme.layout.content.editors.bar)
+        self.tab_bar.grid(row=0, column=0, sticky=tk.EW)
+
+        self.tab_container = Frame(self.tab_bar, bg=self.base.theme.border)
+        self.tab_container.pack(side=tk.LEFT, fill=tk.Y)
+
+        self.action_container = Frame(
+            self.tab_bar, **self.base.theme.layout.content.editors.bar
+        )
+        self.action_container.pack(side=tk.RIGHT, fill=tk.Y, padx=(0, 10))
+
+        self.menu = EditorsbarMenu(self.action_container, "tabs")
+        self.menu.add_command(
+            "Show Opened Editors", lambda: self.base.palette.show("active:")
+        )
+        self.menu.add_command(
+            "Restore Last Closed Editor",
+            self.base.commands.restore_last_closed_editor,
+        )
+        self.menu.add_separator(10)
+        self.menu.add_command("Split Editor", self.base.commands.split_editor)
+        self.menu.add_command(
+            "Split Editor Vertical", self.base.commands.split_editor_vertical
+        )
+        self.menu.add_separator(10)
+        self.menu.add_command(
+            "Close Split",
+            lambda p=self: self.editors_manager.close_pane(p),
+        )
+        self.menu.add_command("Close All", self.editors_manager.delete_all_editors)
+
+        self.buttons: list[IconButton] = []
+        default_buttons = (
+            (Icons.ELLIPSIS, self.menu.show),
+            (Icons.CHEVRON_DOWN, self.base.open_editors.show),
+            (Icons.ADD, self.base.commands.open_empty_editor),
+        )
+
+        for button in default_buttons:
+            if isinstance(button, list | tuple):
+                IconButton(
+                    self.action_container, iconsize=12, pady=6, hfg_only=True, *button
+                ).pack(side=tk.RIGHT, fill=tk.Y)
+            else:
+                IconButton(self.action_container, **button).pack(
+                    side=tk.RIGHT, fill=tk.Y
+                )
+
+        IconButton(
+            self.action_container,
+            Icons.SPLIT_HORIZONTAL,
+            iconsize=12,
+            pady=6,
+            hfg_only=True,
+            event=self.editors_manager.split_editor,
+        ).pack(side=tk.RIGHT, fill=tk.Y)
+
+    def _update_tab_bar_visibility(self) -> None:
+        if self.active_tabs:
+            self.tab_bar.grid()
+        else:
+            self.tab_bar.grid_remove()
+            self.breadcrumbs_container.grid_remove()
+
+    def show_breadcrumbs(self) -> None:
+        self.breadcrumbs.clear()
+        self.breadcrumbs_container.grid()
+
+    def hide_breadcrumbs(self) -> None:
+        self.breadcrumbs_container.grid_remove()
 
     def focus_pane(self, *_) -> None:
         self.editors_manager.set_active_pane(self)
+
+    def is_empty(self) -> bool:
+        return not self.active_tabs
+
+    def set_active_tab(self, tab: Tab) -> None:
+        self.active_tab = tab
+        for t in self.active_tabs:
+            if t != tab:
+                t.deselect()
 
     def set_active_editor(self, editor: Editor | None) -> None:
         if self.active_editor and self.active_editor != editor:
             self.active_editor.grid_remove()
 
         if editor:
-            editor.grid(row=0, column=0, sticky=tk.NSEW, in_=self)
+            editor.grid(row=0, column=0, sticky=tk.NSEW, in_=self.editor_container)
             editor.tkraise()
             self.placeholder.grid_remove()
         else:
@@ -43,8 +147,88 @@ class EditorPane(Frame):
 
         self.active_editor = editor
 
+    def add_tab(self, editor: Editor) -> Tab:
+        tab = Tab(self, editor)
+        tab.pack(fill=tk.Y, side=tk.LEFT, padx=(0, 1), in_=self.tab_container)
+        self.active_tabs.append(tab)
+        tab.select()
+        self._update_tab_bar_visibility()
+        return tab
+
+    def close_tab(self, tab: Tab) -> None:
+        if e := tab.editor:
+            if e.content and e.content.editable and e.content.unsaved_changes:
+                if askyesno(
+                    "Unsaved changes",
+                    f"Do you want to save the changes you made to {e.filename}",
+                ):
+                    if e.exists:
+                        e.save()
+                    else:
+                        self.base.commands.save_file_as()
+
+        try:
+            i = self.active_tabs.index(tab)
+        except ValueError:
+            return
+
+        was_selected = tab == self.active_tab
+        self.active_tabs.pop(i)
+        self.editors_manager.close_editor(tab.editor)
+        tab.destroy()
+
+        self._update_tab_bar_visibility()
+
+        if not self.active_tabs and len(self.editors_manager.panes) > 1:
+            self.after_idle(lambda p=self: p.editors_manager.close_pane(p))
+            return
+
+        if not was_selected:
+            return
+
+        if self.active_tabs:
+            if i < len(self.active_tabs):
+                self.active_tabs[i].select()
+            else:
+                self.active_tabs[i - 1].select()
+        else:
+            self.active_tab = None
+
+    def close_active_tab(self) -> None:
+        if self.active_tab:
+            self.close_tab(self.active_tab)
+
+    def change_tab_forward(self) -> None:
+        if self.active_tab:
+            i = self.active_tabs.index(self.active_tab)
+            self.active_tabs[(i + 1) % len(self.active_tabs)].select()
+
+    def change_tab_back(self) -> None:
+        if self.active_tab:
+            i = self.active_tabs.index(self.active_tab)
+            self.active_tabs[(i - 1) % len(self.active_tabs)].select()
+
+    def clear_tabs(self) -> None:
+        for tab in self.active_tabs:
+            tab.destroy()
+        self.active_tabs.clear()
+        self.active_tab = None
+        self._update_tab_bar_visibility()
+
     def clear(self) -> None:
-        if self.active_editor:
-            self.active_editor.grid_remove()
-            self.active_editor = None
+        self.active_editor = None
         self.placeholder.grid()
+
+    def add_buttons(self, buttons: list[IconButton]) -> None:
+        for button in buttons:
+            button.pack(side=tk.LEFT)
+            self.buttons.append(button)
+
+    def replace_buttons(self, buttons: list[IconButton]) -> None:
+        self.clear_buttons()
+        self.add_buttons(buttons)
+
+    def clear_buttons(self) -> None:
+        for button in self.buttons:
+            button.pack_forget()
+        self.buttons.clear()

--- a/src/biscuit/layout/editors/pane.py
+++ b/src/biscuit/layout/editors/pane.py
@@ -34,12 +34,17 @@ class EditorPane(Frame):
         self.breadcrumbs.pack(fill=tk.X, side=tk.TOP)
         self.breadcrumbs_container.grid_remove()
 
+        self.editor_container = Frame(self)
+        self.editor_container.grid(row=2, column=0, sticky=tk.NSEW)
+        self.editor_container.grid_rowconfigure(0, weight=1)
+        self.editor_container.grid_columnconfigure(0, weight=1)
+
         self.active_tabs: list[Tab] = []
         self.active_tab: Tab | None = None
         self.active_editor: Editor | None = None
 
-        self.placeholder = Placeholder(self)
-        self.placeholder.grid(row=2, column=0, sticky=tk.NSEW)
+        self.placeholder = Placeholder(self.editor_container)
+        self.placeholder.grid(row=0, column=0, sticky=tk.NSEW)
 
         self.bind("<Button-1>", self.focus_pane)
         self.placeholder.bind("<Button-1>", self.focus_pane)
@@ -137,8 +142,14 @@ class EditorPane(Frame):
                 pass
 
         if editor:
-            editor.grid(row=2, column=0, sticky=tk.NSEW)
-            editor.tkraise()
+            try:
+                editor.grid(row=0, column=0, sticky=tk.NSEW, in_=self.editor_container)
+            except tk.TclError:
+                pass
+            try:
+                editor.tkraise()
+            except tk.TclError:
+                pass
             self.placeholder.grid_remove()
         else:
             self.placeholder.grid()

--- a/src/biscuit/layout/editors/tab.py
+++ b/src/biscuit/layout/editors/tab.py
@@ -91,25 +91,47 @@ class Tab(Frame):
 
     def deselect(self, *_) -> None:
         if self.selected:
-            self.editor.grid_remove()
             self.apply_color(self.bg)
             self.closebtn.config(activeforeground=self.fg, fg=self.bg)
             self.selected = False
 
     def select(self, *_) -> None:
-        if not self.selected:
-            self.master.set_active_tab(self)
-            if self.base.active_directory and self.editor.filename:
-                self.base.set_title(
-                    f"{self.editor.filename} - {os.path.basename(self.base.active_directory)}"
-                )
-            elif self.editor.filename:
-                self.base.set_title(self.editor.filename)
-            self.editor.grid(column=0, row=1, sticky=tk.NSEW, in_=self.master.master)
+        editors_manager = self.master.master
 
-            self.apply_color(self.hbg)
-            self.closebtn.config(activeforeground=self.hfg, fg=self.fg)
-            self.selected = True
+        if self.selected:
+            if (
+                self.editor.path
+                and self.editor.exists
+                and self.editor.showpath
+                and not self.editor.diff
+            ):
+                self.master.show_breadcrumbs()
+                self.base.breadcrumbs.set_path(self.editor.path)
+            else:
+                self.master.hide_breadcrumbs()
+            return
+
+        self.master.set_active_tab(self)
+
+        target_pane = editors_manager.active_pane
+        for pane in editors_manager.panes:
+            if pane.active_editor == self.editor:
+                target_pane = pane
+                break
+
+        target_pane.set_active_editor(self.editor)
+        editors_manager.set_active_pane(target_pane)
+
+        if self.base.active_directory and self.editor.filename:
+            self.base.set_title(
+                f"{self.editor.filename} - {os.path.basename(self.base.active_directory)}"
+            )
+        elif self.editor.filename:
+            self.base.set_title(self.editor.filename)
+
+        self.apply_color(self.hbg)
+        self.closebtn.config(activeforeground=self.hfg, fg=self.fg)
+        self.selected = True
 
         if (
             self.editor.path

--- a/src/biscuit/layout/editors/tab.py
+++ b/src/biscuit/layout/editors/tab.py
@@ -10,9 +10,7 @@ from biscuit.common.ui import Frame, Icon, IconButton
 if typing.TYPE_CHECKING:
     from biscuit.editor import Editor
 
-    from .editorsbar import EditorsBar
-
-# TODO: show modified, saved state in the tab
+    from .pane import EditorPane
 
 
 class Tab(Frame):
@@ -22,9 +20,9 @@ class Tab(Frame):
     Shows the filename, icon and close button.
     """
 
-    def __init__(self, master: EditorsBar, editor: Editor, *args, **kwargs) -> None:
+    def __init__(self, master: EditorPane, editor: Editor, *args, **kwargs) -> None:
         super().__init__(master, *args, **kwargs)
-        self.master: EditorsBar = master
+        self.master: EditorPane = master
         self.editor = editor
         self.selected = False
 
@@ -96,31 +94,19 @@ class Tab(Frame):
             self.selected = False
 
     def select(self, *_) -> None:
-        editors_manager = self.master.master
+        pane: EditorPane = self.master
+        editors_manager = pane.editors_manager
 
         if self.selected:
-            if (
-                self.editor.path
-                and self.editor.exists
-                and self.editor.showpath
-                and not self.editor.diff
-            ):
-                self.master.show_breadcrumbs()
-                self.base.breadcrumbs.set_path(self.editor.path)
-            else:
-                self.master.hide_breadcrumbs()
+            editors_manager.set_active_pane(pane)
+            self._update_breadcrumbs()
             return
 
-        self.master.set_active_tab(self)
+        pane.set_active_tab(self)
+        editors_manager.set_active_pane(pane)
 
-        target_pane = editors_manager.active_pane
-        for pane in editors_manager.panes:
-            if pane.active_editor == self.editor:
-                target_pane = pane
-                break
-
-        target_pane.set_active_editor(self.editor)
-        editors_manager.set_active_pane(target_pane)
+        self.editor.grid(row=0, column=0, sticky=tk.NSEW, in_=pane.editor_container)
+        pane.set_active_editor(self.editor)
 
         if self.base.active_directory and self.editor.filename:
             self.base.set_title(
@@ -133,13 +119,17 @@ class Tab(Frame):
         self.closebtn.config(activeforeground=self.hfg, fg=self.fg)
         self.selected = True
 
+        self._update_breadcrumbs()
+
+    def _update_breadcrumbs(self) -> None:
+        pane = self.master
         if (
             self.editor.path
             and self.editor.exists
             and self.editor.showpath
             and not self.editor.diff
         ):
-            self.master.show_breadcrumbs()
-            self.base.breadcrumbs.set_path(self.editor.path)
+            pane.show_breadcrumbs()
+            pane.breadcrumbs.set_path(self.editor.path)
         else:
-            self.master.hide_breadcrumbs()
+            pane.hide_breadcrumbs()

--- a/src/biscuit/layout/editors/tab.py
+++ b/src/biscuit/layout/editors/tab.py
@@ -105,7 +105,6 @@ class Tab(Frame):
         pane.set_active_tab(self)
         editors_manager.set_active_pane(pane)
 
-        self.editor.grid(row=0, column=0, sticky=tk.NSEW, in_=pane.editor_container)
         pane.set_active_editor(self.editor)
 
         if self.base.active_directory and self.editor.filename:

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"


### PR DESCRIPTION
Implements the split editor feature (Ctrl+\\ to toggle). EditorsManager now uses a PanedWindow with EditorPane instances instead of placing editors directly. Each pane shows one editor at a time, and clicking a tab routes the editor to the currently active pane.