### PR TITLE
feat(ai): add MiniMax provider support

### DIFF
--- a/src/biscuit/common/ai/agent.py
+++ b/src/biscuit/common/ai/agent.py
@@ -31,6 +31,10 @@ import anthropic
 from .state import AgentState, AgentStep, AgentTask
 from .tools import get_biscuit_tools
 
+# MiniMax exposes an Anthropic-compatible Messages API at this regional endpoint
+# (global region). The China region uses https://api.minimaxi.com/anthropic.
+MINIMAX_ANTHROPIC_BASE_URL = "https://api.minimax.io/anthropic"
+
 if typing.TYPE_CHECKING:
     from biscuit import App
 
@@ -84,12 +88,40 @@ class Agent:
             )
         )
 
-    def _initialize_anthropic_client(self) -> anthropic.AsyncAnthropic:
-        """Initialize the Anthropic client."""
+    def _initialize_anthropic_client(self, base_url: str = None) -> anthropic.AsyncAnthropic:
+        """Initialize the Anthropic client.
+
+        An optional ``base_url`` lets the client target an Anthropic-compatible
+        provider such as MiniMax, which serves the Messages API from its own
+        regional endpoint.
+        """
         if not self.api_key:
             raise ValueError("API key must be provided")
-        
-        return anthropic.AsyncAnthropic(api_key=self.api_key)
+
+        kwargs = {"api_key": self.api_key}
+        if base_url:
+            kwargs["base_url"] = base_url
+        return anthropic.AsyncAnthropic(**kwargs)
+
+    def _initialize_minimax_client(self) -> anthropic.AsyncAnthropic:
+        """Initialize the MiniMax client.
+
+        MiniMax provides an Anthropic-compatible Messages API, so the Anthropic
+        async client is reused with the MiniMax regional base URL.
+        """
+        return self._initialize_anthropic_client(base_url=MINIMAX_ANTHROPIC_BASE_URL)
+
+    def _is_minimax_model(self) -> bool:
+        """Whether the configured model is served by the MiniMax provider."""
+        return self.model_name.lower().startswith("minimax")
+
+    def _is_anthropic_compatible(self) -> bool:
+        """Whether the model can be driven through the Anthropic Messages API.
+
+        Native Anthropic models and MiniMax models both use this path; MiniMax
+        is reached through its own regional base URL.
+        """
+        return "claude" in self.model_name.lower() or self._is_minimax_model()
 
     # --- Callbacks Configuration ---
 
@@ -159,7 +191,9 @@ class Agent:
 
         try:
             # Force recreation of the client on the current loop/thread
-            if "claude" in self.model_name.lower():
+            if self._is_minimax_model():
+                self.anthropic_client = self._initialize_minimax_client()
+            elif "claude" in self.model_name.lower():
                 self.anthropic_client = self._initialize_anthropic_client()
             else:
                 self.gemini_client = self._initialize_gemini_client()
@@ -180,7 +214,7 @@ class Agent:
 
     async def _run_chat_session(self, task: AgentTask, inputs: str):
         """Routes the task to the appropriate provider."""
-        if "claude" in self.model_name.lower():
+        if self._is_anthropic_compatible():
             await self._run_anthropic_session(task, inputs)
         else:
             await self._run_gemini_session(task, inputs)
@@ -508,8 +542,11 @@ Rules: Use tools to read/edit code. Execute plans immediately. Be concise."""
 
     def process_message(self, message: str) -> str:
         """Single-turn message processing (Backwards Compatibility)."""
-        if "claude" in self.model_name.lower():
-            client = anthropic.Anthropic(api_key=self.api_key)
+        if self._is_anthropic_compatible():
+            client_kwargs = {"api_key": self.api_key}
+            if self._is_minimax_model():
+                client_kwargs["base_url"] = MINIMAX_ANTHROPIC_BASE_URL
+            client = anthropic.Anthropic(**client_kwargs)
             response = client.messages.create(
                 model=self.model_name,
                 max_tokens=1000,

--- a/src/biscuit/views/ai/ai.py
+++ b/src/biscuit/views/ai/ai.py
@@ -49,9 +49,11 @@ class AI(SideBarView):
             "Claude 4 Sonnet": "claude-sonnet-4-20250514",
             "Claude 3.5 Sonnet": "claude-3-5-sonnet-20241022",
             "Claude 3.5 Haiku": "claude-3-5-haiku-20241022",
+            "MiniMax M3": "MiniMax-M3",
+            "MiniMax M2.7": "MiniMax-M2.7",
         }
         self.current_model = "Gemini 2.0 Flash"
-        self.api_keys = {"gemini": "", "anthropic": ""}
+        self.api_keys = {"gemini": "", "anthropic": "", "minimax": ""}
 
         self.top.grid_columnconfigure(self.column, weight=1)
 
@@ -74,13 +76,14 @@ class AI(SideBarView):
             """
         )
 
-        self.cursor.execute("SELECT key, value FROM secrets WHERE key IN ('GEMINI_API_KEY', 'ANTHROPIC_API_KEY')")
+        self.cursor.execute("SELECT key, value FROM secrets WHERE key IN ('GEMINI_API_KEY', 'ANTHROPIC_API_KEY', 'MINIMAX_API_KEY')")
         keys = dict(self.cursor.fetchall())
         self.api_keys["gemini"] = keys.get("GEMINI_API_KEY", "")
         self.api_keys["anthropic"] = keys.get("ANTHROPIC_API_KEY", "")
+        self.api_keys["minimax"] = keys.get("MINIMAX_API_KEY", "")
 
         self.placeholder = AIPlaceholder(self)
-        if self.api_keys["gemini"] or self.api_keys["anthropic"]:
+        if self.api_keys["gemini"] or self.api_keys["anthropic"] or self.api_keys["minimax"]:
             self.add_chat()
         else:
             self.add_placeholder()
@@ -128,7 +131,7 @@ class AI(SideBarView):
         if not self.api_key:
             return self.add_placeholder()
 
-    def save_keys(self, gemini: str = None, anthropic: str = None) -> None:
+    def save_keys(self, gemini: str = None, anthropic: str = None, minimax: str = None) -> None:
         """Save API keys to database and start chat."""
         if gemini:
             self.api_keys["gemini"] = gemini
@@ -136,7 +139,10 @@ class AI(SideBarView):
         if anthropic:
             self.api_keys["anthropic"] = anthropic
             self.cursor.execute("INSERT OR REPLACE INTO secrets (key, value) VALUES ('ANTHROPIC_API_KEY', ?)", (anthropic,))
-        
+        if minimax:
+            self.api_keys["minimax"] = minimax
+            self.cursor.execute("INSERT OR REPLACE INTO secrets (key, value) VALUES ('MINIMAX_API_KEY', ?)", (minimax,))
+
         self.db.commit()
         self.add_chat()
 
@@ -154,7 +160,12 @@ class AI(SideBarView):
 
         try:
             model_id = self.available_models[self.current_model]
-            provider = "anthropic" if "claude" in model_id else "gemini"
+            if "claude" in model_id:
+                provider = "anthropic"
+            elif model_id.lower().startswith("minimax"):
+                provider = "minimax"
+            else:
+                provider = "gemini"
             api_key = self.api_keys[provider]
 
             if not api_key:

--- a/src/biscuit/views/ai/placeholder.py
+++ b/src/biscuit/views/ai/placeholder.py
@@ -12,8 +12,8 @@ if typing.TYPE_CHECKING:
 
 class AIPlaceholder(Frame):
     """Home page for the AI assistant view.
-    
-    Now supports both Google Gemini and Anthropic Claude."""
+
+    Now supports Google Gemini, Anthropic Claude, and MiniMax."""
 
     def __init__(self, master, *args, **kwargs) -> None:
         super().__init__(master, *args, **kwargs)
@@ -32,24 +32,35 @@ class AIPlaceholder(Frame):
         # --- Gemini Section ---
         gemini_frame = Frame(self, **self.base.theme.views.sidebar.item)
         gemini_frame.pack(fill=tk.X, pady=5)
-        
-        Label(gemini_frame, text="Google Gemini", font=self.base.settings.uifont_bold, 
+
+        Label(gemini_frame, text="Google Gemini", font=self.base.settings.uifont_bold,
               anchor=tk.W, **self.base.theme.views.sidebar.item.content).pack(fill=tk.X)
-        
+
         self.gemini_key = tk.StringVar(value=self.master.api_keys.get("gemini", ""))
         self.gemini_entry = Entry(gemini_frame, hint="Gemini API Key...", textvariable=self.gemini_key)
         self.gemini_entry.pack(fill=tk.X, pady=2)
-        
+
         # --- Anthropic Section ---
         anthropic_frame = Frame(self, **self.base.theme.views.sidebar.item)
         anthropic_frame.pack(fill=tk.X, pady=10)
 
-        Label(anthropic_frame, text="Anthropic Claude", font=self.base.settings.uifont_bold, 
+        Label(anthropic_frame, text="Anthropic Claude", font=self.base.settings.uifont_bold,
               anchor=tk.W, **self.base.theme.views.sidebar.item.content).pack(fill=tk.X)
-        
+
         self.anthropic_key = tk.StringVar(value=self.master.api_keys.get("anthropic", ""))
         self.anthropic_entry = Entry(anthropic_frame, hint="Anthropic API Key...", textvariable=self.anthropic_key)
         self.anthropic_entry.pack(fill=tk.X, pady=2)
+
+        # --- MiniMax Section ---
+        minimax_frame = Frame(self, **self.base.theme.views.sidebar.item)
+        minimax_frame.pack(fill=tk.X, pady=10)
+
+        Label(minimax_frame, text="MiniMax", font=self.base.settings.uifont_bold,
+              anchor=tk.W, **self.base.theme.views.sidebar.item.content).pack(fill=tk.X)
+
+        self.minimax_key = tk.StringVar(value=self.master.api_keys.get("minimax", ""))
+        self.minimax_entry = Entry(minimax_frame, hint="MiniMax API Key...", textvariable=self.minimax_key)
+        self.minimax_entry.pack(fill=tk.X, pady=2)
 
         confirm_btn = IconLabelButton(
             self,
@@ -67,7 +78,7 @@ class AIPlaceholder(Frame):
             link="https://aistudio.google.com/app/apikey",
         )
         self.link.pack(fill=tk.X)
-        
+
         self.link2 = WebLinkLabel(
             self,
             text="Get Anthropic Key",
@@ -75,5 +86,12 @@ class AIPlaceholder(Frame):
         )
         self.link2.pack(fill=tk.X)
 
+        self.link3 = WebLinkLabel(
+            self,
+            text="Get MiniMax Key",
+            link="https://platform.minimax.io/docs",
+        )
+        self.link3.pack(fill=tk.X)
+
     def start_chat(self) -> None:
-        self.master.save_keys(self.gemini_key.get(), self.anthropic_key.get())
+        self.master.save_keys(self.gemini_key.get(), self.anthropic_key.get(), self.minimax_key.get())


### PR DESCRIPTION
Reason: provider-add — register the MiniMax text models (MiniMax-M3 and MiniMax-M2.7) as a working provider with a regional endpoint and credential path instead of routing them through the Gemini SDK.

## Changes

- **Model registry** (`src/biscuit/views/ai/ai.py`): add `MiniMax-M3` and `MiniMax-M2.7` to the `available_models` selector so they can be picked from the UI.
- **Credential path** (`src/biscuit/views/ai/ai.py`, `src/biscuit/views/ai/placeholder.py`): add a `minimax` API key slot stored in the existing secrets database under `MINIMAX_API_KEY`, with a dedicated entry field and documentation link in the AI placeholder. `save_keys` now accepts and persists the MiniMax key.
- **Provider routing** (`src/biscuit/views/ai/ai.py`): resolve the provider from the model id (`minimax` for `MiniMax-*` models) and pass the matching API key to the agent.
- **Client wiring** (`src/biscuit/common/ai/agent.py`): MiniMax exposes an Anthropic-compatible Messages API, so the Anthropic async client is reused with the MiniMax regional base URL `https://api.minimax.io/anthropic` (global region). MiniMax models now flow through `_run_anthropic_session` and the single-turn `process_message` path with the correct base URL, instead of being misrouted to the Gemini SDK.

## Verification

- `python3 -m py_compile` on the three modified Python files (no syntax errors).
- `git diff` scanned for secrets (none found).
